### PR TITLE
Add Matrix-themed Hyprland configuration

### DIFF
--- a/.config/alacritty/alacritty.yml
+++ b/.config/alacritty/alacritty.yml
@@ -1,0 +1,41 @@
+# Alacritty Terminal Configuration - Matrix Theme
+env:
+  TERM: xterm-256color
+
+colors:
+  # Default colors
+  primary:
+    background: '0x000000'   # black background
+    foreground: '0x27F546'   # bright green text
+  cursor:
+    text: '0x000000'         # cursor text (when block cursor covers text)
+    cursor: '0x27F546'       # cursor color (green)
+  selection:
+    text: '0x000000'         # text color when selected
+    background: '0x27F546'   # selection highlight background (green)
+
+  # Normal ANSI colors
+  normal:
+    black:   '0x000000'
+    red:     '0xFF0000'
+    green:   '0x009417'   # use secondary green for "green"
+    yellow:  '0xFFFF00'
+    blue:    '0x0000FF'
+    magenta: '0xFF00FF'
+    cyan:    '0x00FFFF'
+    white:   '0xC0C0C0'
+  # Bright ANSI colors
+  bright:
+    black:   '0x505050'
+    red:     '0xFF5555'
+    green:   '0x27F546'   # bright green
+    yellow:  '0xFFFF55'
+    blue:    '0x5555FF'
+    magenta: '0xFF55FF'
+    cyan:    '0x55FFFF'
+    white:   '0xFFFFFF'
+
+font:
+  normal:
+    family: monospace
+    size: 11.0

--- a/.config/hypr/hyprland.conf
+++ b/.config/hypr/hyprland.conf
@@ -1,0 +1,70 @@
+# Hyprland Configuration - Matrix Green Theme
+
+## ── General Settings ─────────────────────────
+# Set user-defined $mods for convenience (optional)
+$mainMod = SUPER
+
+# No window rounding, neon green borders
+decoration {
+    rounding = 0                # sharp corners, no rounding
+    blur = false                # disable blur if any
+    drop_shadow = false         # no shadows for a crisp look
+    border_size = 2             # 2px border width for windows
+}
+
+# Color scheme: use solid greens for active/inactive borders
+# (Format 0xAARRGGBB – here AA=ff for full opacity)
+col.active_border   = 0xff27f546  # bright green for active window border
+col.inactive_border = 0xff009417  # darker green for inactive windows
+
+# Gaps between windows (for tiling)
+gaps_in  = 4    # small gap between windows (helps separate double borders)
+gaps_out = 0    # no outer gap (windows touch screen edges, bar will reserve space)
+
+# Set wallpaper to black (solid color)
+exec-once = swaybg -c "#000000"   # requires swaybg installed; fills background with black
+
+## ── Keybindings ─────────────────────────────
+# Format: bind = MOD, key, action, argument
+# Window management
+bind = SUPER, Q, killactive      # Super+Q closes the focused window
+bind = SUPER, C, togglefloating  # Super+C toggles floating (detach/attach)
+bind = SUPER, V, togglefloating
+bind = SUPER, V, centerwindow, 1 # Super+V: float (if not already) and center window on screen
+
+bind = SUPER, F, exec, dolphin    # Super+F launches Dolphin file manager
+bind = SUPER, B, exec, firefox    # Super+B launches Firefox browser
+bind = SUPER, Enter, exec, alacritty  # Super+Enter opens Alacritty terminal
+bind = SUPER, Space, exec, wofi --show drun   # Super+Space opens Wofi launcher (drun mode)
+
+# Window focus navigation (arrow keys to move focus)
+bind = SUPER, Left,  movefocus, l
+bind = SUPER, Down,  movefocus, d
+bind = SUPER, Up,    movefocus, u
+bind = SUPER, Right, movefocus, r
+
+# Move window to different workspace (Super+Ctrl+←/→)
+bind = SUPER_CTRL, Left,  movetoworkspacesilent, m-1   # send to previous workspace on this monitor
+bind = SUPER_CTRL, Right, movetoworkspacesilent, m+1  # send to next workspace on this monitor
+
+# Workspace switching (Super+Number row) – optional, 1-9 keys to switch to workspace
+bind = SUPER, 1, workspace, 1
+bind = SUPER, 2, workspace, 2
+bind = SUPER, 3, workspace, 3
+# ... (repeat for more workspaces if needed)
+
+## ── Window Rules ────────────────────────────
+# Float and center the Wofi launcher when it appears, so it’s not tiled
+windowrule = float, class:Wofi              # make wofi windows floating
+windowrule = center 1, class:Wofi           # center wofi on screen (respect reserved bar area)
+
+# Force certain apps to start in dark mode if possible (Dolphin picks up Qt theme)
+# e.g., for Electron apps or GTK apps one might set environment variables (not needed for Dolphin)
+
+## ── Autostart (exec-once) ───────────────────
+exec-once = waybar &          # start Waybar (status bar)
+exec-once = alacritty &       # launch a terminal at startup (so user has a shell open)
+# (Polkit agent, notifications, etc., can be started here if needed)
+
+# NOTE: Ensure Waybar and Wofi are installed. Wofi does not run as daemon; it's launched via keybind.
+# The above commands with '&' run them in background so Hyprland can continue startup.

--- a/.config/waybar/config
+++ b/.config/waybar/config
@@ -1,0 +1,46 @@
+{
+  // Waybar configuration for Matrix theme
+  "layer": "top",                // layer: top so it stays above windows
+  "position": "top",             // stick to top of screen
+  "height": 30,
+  "margin": 0,
+  "modules-left": [],            // no modules on left (clean look)
+  "modules-center": [],          // no modules in center
+  "modules-right": [ "network", "cpu", "memory", "temperature", "clock" ],
+  // Format and behavior of each module:
+  "network": {
+    "interface": "wl*",                          // use first wireless interface (Wi-Fi)
+    "format": "WIFI: {essid} ({signalStrength}%)", // Wi-Fi name and signal percent
+    "format-disconnected": "WIFI: disconnected",
+    "interval": 10
+  },
+  "cpu": {
+    "format": "CPU {usage}%",                   // CPU usage percentage
+    "interval": 3                               // update more frequently (3s)
+  },
+  "memory": {
+    "format": "RAM {percentage}%",              // RAM usage percentage
+    "interval": 5
+  },
+  "temperature": {
+    "thermal-zone": 0,                         // use thermal zone 0 (CPU)
+    "format": "TEMP {temperatureC}°C",
+    "interval": 5
+  },
+  "clock": {
+    "format": "{:%Y-%m-%d %H:%M}",             // Date and 24h time (YYYY-MM-DD HH:MM)
+    "interval": 60,
+    "tooltip": false
+  },
+  // You can add more modules here (e.g., "battery", "volume") if needed:
+  /*
+  "battery": {
+    "format": "BAT {capacity}%",
+    "hide-full": true
+  },
+  "pulseaudio": {
+    "format": "VOL {volume}%"
+  },
+  */
+  "tooltip": false  // disable tooltips globally for cleanliness
+}

--- a/.config/waybar/style.css
+++ b/.config/waybar/style.css
@@ -1,0 +1,25 @@
+/* Waybar CSS for Matrix theme */
+#waybar {
+  background: #000000;
+  color: #27F546;
+  font-family: monospace;           /* Monospace font for terminal feel (uses system default monospace) */
+  border-bottom: 2px solid #27F546; /* a thin green line at bottom of bar (Tron-style outline) */
+}
+#waybar .module {
+  padding: 0 10px;
+}
+#waybar .modules-right > *:not(:last-child) {
+  margin-right: 20px; /* spacing between modules */
+}
+#waybar .module:hover {
+  color: #009417;     /* on hover, slightly darker green highlight */
+}
+/* Optional: style specific modules by ID if needed */
+#network, #cpu, #memory, #temperature, #clock {
+  font-weight: bold;
+}
+
+/* Hide unnecessary elements */
+#workspaces, #mode, #window, #launcher {
+  display: none;
+}

--- a/.config/wofi/config
+++ b/.config/wofi/config
@@ -1,0 +1,10 @@
+# Wofi configuration (ini format)
+[settings]
+mode = drun,run              # show both desktop apps (drun) and command launcher (run)
+terminal = alacritty         # use Alacritty for launching terminal apps
+show_icons = false           # do not show icons (text only, for speed and minimalism)
+hide_scroll = true           # hide scrollbar (we'll scroll with keyboard if needed)
+case_insensitive = true      # case-insensitive search for convenience (insensitive)
+prompt =                     # no prompt text (clean look)
+width = 30%                  # width of Wofi window (30% of screen)
+height = 30%                 # height of Wofi window (30% of screen)

--- a/.config/wofi/style.css
+++ b/.config/wofi/style.css
@@ -1,0 +1,25 @@
+/* Wofi CSS for Matrix theme */
+window {
+  background-color: #000000;
+  color: #27F546;
+  /* Center the Wofi window by letting Hyprland's rule handle positioning */
+}
+#input {
+  background-color: #000000;
+  color: #27F546;
+  border: 2px solid #27F546;
+  border-radius: 0;
+}
+#scroll {
+  background-color: #000000;
+  color: #27F546;
+  border: 2px solid #27F546;
+  border-top-width: 0;  /* merge input and list borders */
+}
+#entry {
+  color: #27F546;
+}
+#entry:selected {
+  background-color: #27F546;
+  color: #000000; /* highlighted selection: green background, black text */
+}


### PR DESCRIPTION
## Summary
- add Matrix-inspired Hyprland config with green-on-black theme
- configure Waybar, Wofi, and Alacritty to match the theme

## Testing
- `pytest` (no tests found)


------
https://chatgpt.com/codex/tasks/task_e_688d8ae9fdc08330b545025d2e5825b4