### PR TITLE
feat: integrate tray helpers and GUI install script

### DIFF
--- a/.config/hypr/hyprland.conf
+++ b/.config/hypr/hyprland.conf
@@ -69,7 +69,14 @@ windowrule = center 1, class:Wofi           # center wofi on screen (respect res
 ## ── Autostart (exec-once) ───────────────────
 exec-once = waybar &          # start Waybar (status bar)
 exec-once = alacritty &       # launch a terminal at startup (so user has a shell open)
-# (Polkit agent, notifications, etc., can be started here if needed)
+
+#######################################
+#  helpers & tray items (Matrix-style)
+#######################################
+exec-once = /usr/lib/polkit-gnome/polkit-gnome-authentication-agent-1 &
+exec-once = nm-applet --indicator &
+exec-once = blueman-applet &
+exec-once = udiskie &
 
 # NOTE: Ensure Waybar and Wofi are installed. Wofi does not run as daemon; it's launched via keybind.
 # The above commands with '&' run them in background so Hyprland can continue startup.

--- a/.config/waybar/config
+++ b/.config/waybar/config
@@ -1,46 +1,14 @@
 {
-  // Waybar configuration for Matrix theme
-  "layer": "top",                // layer: top so it stays above windows
-  "position": "top",             // stick to top of screen
-  "height": 30,
-  "margin": 0,
-  "modules-left": [],            // no modules on left (clean look)
-  "modules-center": [],          // no modules in center
-  "modules-right": [ "network", "cpu", "memory", "temperature", "clock" ],
-  // Format and behavior of each module:
-  "network": {
-    "interface": "wl*",                          // use first wireless interface (Wi-Fi)
-    "format": "WIFI: {essid} ({signalStrength}%)", // Wi-Fi name and signal percent
-    "format-disconnected": "WIFI: disconnected",
-    "interval": 10
+  "layer": "top",
+  "modules-left":  [ "hyprland/workspaces", "tray", "clock" ],
+  "modules-right": [ "pulseaudio", "network", "bluetooth", "battery" ],
+
+  "tray": {
+    "icon-size": 18,
+    "spacing":   6
   },
-  "cpu": {
-    "format": "CPU {usage}%",                   // CPU usage percentage
-    "interval": 3                               // update more frequently (3s)
-  },
-  "memory": {
-    "format": "RAM {percentage}%",              // RAM usage percentage
-    "interval": 5
-  },
-  "temperature": {
-    "thermal-zone": 0,                         // use thermal zone 0 (CPU)
-    "format": "TEMP {temperatureC}°C",
-    "interval": 5
-  },
-  "clock": {
-    "format": "{:%Y-%m-%d %H:%M}",             // Date and 24h time (YYYY-MM-DD HH:MM)
-    "interval": 60,
-    "tooltip": false
-  },
-  // You can add more modules here (e.g., "battery", "volume") if needed:
-  /*
-  "battery": {
-    "format": "BAT {capacity}%",
-    "hide-full": true
-  },
-  "pulseaudio": {
-    "format": "VOL {volume}%"
-  },
-  */
-  "tooltip": false  // disable tooltips globally for cleanliness
+  "pulseaudio": { "format": "{volume}%" },
+  "network":    { "format-wifi": "{essid} ", "format-ethernet": "{ifname} " },
+  "bluetooth":  { "format-on": "", "format-off": "" }
 }
+

--- a/.config/waybar/style.css
+++ b/.config/waybar/style.css
@@ -1,25 +1,32 @@
-/* Waybar CSS for Matrix theme */
+/* Matrix-style Waybar CSS */
 #waybar {
-  background: #000000;
-  color: #27F546;
-  font-family: monospace;           /* Monospace font for terminal feel (uses system default monospace) */
-  border-bottom: 2px solid #27F546; /* a thin green line at bottom of bar (Tron-style outline) */
+  background-color: #000000;
+  color: #00ff00;
+  font-family: monospace;
+  border: 2px solid #00ff00;
 }
+
 #waybar .module {
   padding: 0 10px;
 }
-#waybar .modules-right > *:not(:last-child) {
-  margin-right: 20px; /* spacing between modules */
-}
+
 #waybar .module:hover {
-  color: #009417;     /* on hover, slightly darker green highlight */
-}
-/* Optional: style specific modules by ID if needed */
-#network, #cpu, #memory, #temperature, #clock {
-  font-weight: bold;
+  background-color: #001900;
 }
 
-/* Hide unnecessary elements */
-#workspaces, #mode, #window, #launcher {
-  display: none;
+#workspaces button {
+  border: 1px solid #00ff00;
+  padding: 0 5px;
+  margin: 2px;
+  color: #00ff00;
 }
+
+#workspaces button.active {
+  background-color: #00ff00;
+  color: #000000;
+}
+
+#tray > * {
+  margin: 0 3px;
+}
+

--- a/install_gui.sh
+++ b/install_gui.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+sudo pacman -S --needed \
+  networkmanager network-manager-applet nm-connection-editor \
+  polkit-gnome bluez bluez-utils blueman \
+  pavucontrol helvum xfce4-power-manager udiskie \
+  nwg-displays waybar && \
+paru -S --needed hyprgui-git && \
+systemctl enable --now NetworkManager bluetooth && \
+hyprctl reload
+


### PR DESCRIPTION
## Summary
- add Matrix-style tray helpers to Hyprland autostart
- show tray, audio, network, bluetooth and battery widgets in Waybar
- add GUI package installer script

## Testing
- `bash -n install_gui.sh`
- `sed 's://.*::' .config/waybar/config | jq empty`


------
https://chatgpt.com/codex/tasks/task_e_688dabf7b74483309f74248eff20cd5c