### PR TITLE
Fix Hyprland config and clarify Waybar modules

### DIFF
--- a/.config/hypr/hyprland.conf
+++ b/.config/hypr/hyprland.conf
@@ -35,7 +35,7 @@ exec-once = swaybg -c "#000000"   # requires swaybg installed; fills background 
 bind = SUPER, Q, killactive      # Super+Q closes the focused window
 bind = SUPER, C, togglefloating  # Super+C toggles floating (detach/attach)
 bind = SUPER, V, togglefloating    # Super+V: float window
-bind = SUPER, V, centerwindow, 1   # ...centered on screen
+bind = SUPER, V, centerwindow      # ...centered on screen
 bind = SUPER, V, resizewindowpixel, exact 1600 900  # ...and widened for easier viewing
 
 bind = SUPER, F, exec, dolphin    # Super+F launches Dolphin file manager
@@ -64,7 +64,7 @@ bind = SUPER, 3, workspace, 3
 ## ── Window Rules ────────────────────────────
 # Float and center the Wofi launcher when it appears, so it’s not tiled
 windowrule = float, class:Wofi              # make wofi windows floating
-windowrule = center 1, class:Wofi           # center wofi on screen (respect reserved bar area)
+windowrule = center, class:Wofi             # center wofi on screen (respect reserved bar area)
 
 # Force certain apps to start in dark mode if possible (Dolphin picks up Qt theme)
 # e.g., for Electron apps or GTK apps one might set environment variables (not needed for Dolphin)

--- a/.config/waybar/config
+++ b/.config/waybar/config
@@ -2,15 +2,44 @@
   "layer": "top",
   "position": "top",
   "height": 24,
-  "modules-left":  [ "hyprland/workspaces", "tray", "clock" ],
-  "modules-right": [ "pulseaudio", "network", "bluetooth", "battery" ],
+  "modules-left":  [ "hyprland/workspaces", "clock" ],
+  "modules-right": [ "tray", "pulseaudio", "network", "bluetooth", "battery" ],
 
   "tray": {
     "icon-size": 18,
     "spacing":   6
   },
-  "pulseaudio": { "format": "{volume}%" },
-  "network":    { "format-wifi": "{essid} ", "format-ethernet": "{ifname} " },
-  "bluetooth":  { "format-on": "", "format-off": "" }
+
+  "clock": {
+    "format": "Time: {:%H:%M}",
+    "tooltip": true,
+    "tooltip-format": "{:%A, %B %d %Y\\n%H:%M:%S}"
+  },
+
+  "pulseaudio": {
+    "format": "Vol: {volume}% {icon}",
+    "format-muted": "Vol: muted",
+    "tooltip-format": "{desc}\\nVolume: {volume}%\\nMuted: {muted}"
+  },
+
+  "network": {
+    "format-wifi": "Net: {essid} ({signalStrength}%) ",
+    "format-ethernet": "Net: {ifname} ",
+    "format-disconnected": "Net: down",
+    "tooltip-format": "{ifname}\\nIP: {ipaddr}\\nDown: {downspeed}\\nUp: {upspeed}"
+  },
+
+  "bluetooth": {
+    "format-on": "BT: on",
+    "format-off": "BT: off",
+    "tooltip-format": "{status}"
+  },
+
+  "battery": {
+    "format": "Bat: {capacity}% {icon}",
+    "format-charging": "Bat: {capacity}% ⚡",
+    "format-full": "Bat: full",
+    "tooltip-format": "{status}\\nCapacity: {capacity}%\\nTime: {time}"
+  }
 }
 

--- a/.config/waybar/style.css
+++ b/.config/waybar/style.css
@@ -10,10 +10,13 @@
 
 #waybar .module {
   padding: 0 10px;
+  border: 1px solid #00ff00;
+  margin: 0 2px;
 }
 
 #waybar .module:hover {
   background-color: #001900;
+  border-color: #00ff00;
 }
 
 #workspaces button {


### PR DESCRIPTION
## Summary
- fix Hyprland binding and Wofi centering rule
- label Waybar modules with tooltips and keep bar at top
- outline Waybar modules for clearer visuals

## Testing
- `jq . .config/waybar/config`

------
https://chatgpt.com/codex/tasks/task_e_688dcbc40134833082e2ff196e9209df