### PR TITLE
Fix Hyprland keybinding and add ASCII bars to Waybar

### DIFF
--- a/.config/hypr/hyprland.conf
+++ b/.config/hypr/hyprland.conf
@@ -40,7 +40,7 @@ bind = $mainMod, V, exec, sh -c 'hyprctl dispatch togglefloating; hyprctl dispat
 
 bind = $mainMod, F, exec, dolphin    # Super+F launches Dolphin file manager
 bind = $mainMod, B, exec, firefox    # Super+B launches Firefox browser
-bind = $mainMod, Enter, exec, alacritty  # Super+Enter opens Alacritty terminal
+bind = $mainMod, Return, exec, alacritty  # Super+Enter opens Alacritty terminal
 bind = $mainMod, Space, exec, wofi --show drun   # Super+Space opens Wofi launcher (drun mode)
 
 # Window focus navigation (arrow keys to move focus)

--- a/.config/waybar/config
+++ b/.config/waybar/config
@@ -17,29 +17,74 @@
   },
 
   "pulseaudio": {
-    "format": "Vol: {volume}% {icon}",
-    "format-muted": "Vol: muted",
-    "tooltip-format": "{desc}\\nVolume: {volume}%\\nMuted: {muted}"
+    "format": "Vol: {icon} {volume}%",
+    "format-muted": "Vol: [muted] 0%",
+    "tooltip": true,
+    "tooltip-format": "{desc}\\nVolume: {volume}%\\nMuted: {muted}",
+    "format-icons": {
+      "default": [
+        "[----------]",
+        "[#---------]",
+        "[##--------]",
+        "[###-------]",
+        "[####------]",
+        "[#####-----]",
+        "[######----]",
+        "[#######---]",
+        "[########--]",
+        "[#########-]",
+        "[##########]"
+      ]
+    }
   },
 
   "network": {
-    "format-wifi": "Net: {essid} ({signalStrength}%) ",
+    "format-wifi": "Net: {icon} {signalStrength}% {essid}",
     "format-ethernet": "Net: {ifname} ",
     "format-disconnected": "Net: down",
-    "tooltip-format": "{ifname}\\nIP: {ipaddr}\\nDown: {downspeed}\\nUp: {upspeed}"
+    "tooltip": true,
+    "tooltip-format": "{ifname}\\nIP: {ipaddr}\\nDown: {downspeed}\\nUp: {upspeed}",
+    "format-icons": [
+      "[----------]",
+      "[#---------]",
+      "[##--------]",
+      "[###-------]",
+      "[####------]",
+      "[#####-----]",
+      "[######----]",
+      "[#######---]",
+      "[########--]",
+      "[#########-]",
+      "[##########]"
+    ]
   },
 
   "bluetooth": {
     "format-on": "BT: on",
     "format-off": "BT: off",
+    "tooltip": true,
     "tooltip-format": "{status}"
   },
 
   "battery": {
-    "format": "Bat: {capacity}% {icon}",
-    "format-charging": "Bat: {capacity}% ⚡",
-    "format-full": "Bat: full",
-    "tooltip-format": "{status}\\nCapacity: {capacity}%\\nTime: {time}"
+    "format": "Bat: {icon} {capacity}%",
+    "format-charging": "Bat: {icon} {capacity}% ⚡",
+    "format-full": "Bat: [##########] {capacity}%",
+    "tooltip": true,
+    "tooltip-format": "{status}\\nCapacity: {capacity}%\\nTime: {time}",
+    "format-icons": [
+      "[----------]",
+      "[#---------]",
+      "[##--------]",
+      "[###-------]",
+      "[####------]",
+      "[#####-----]",
+      "[######----]",
+      "[#######---]",
+      "[########--]",
+      "[#########-]",
+      "[##########]"
+    ]
   }
 }
 

--- a/install.sh
+++ b/install.sh
@@ -11,7 +11,7 @@ CONFIG_DEST="$TARGET_HOME/.config"
 printf 'Installing configuration for user %s in %s\n' "$TARGET_USER" "$CONFIG_DEST"
 
 # Check for common dependencies and warn if missing
-needed=(alacritty hyprland waybar wofi swaybg)
+needed=(alacritty hyprland waybar wofi swaybg dolphin firefox)
 missing=()
 for cmd in "${needed[@]}"; do
     if ! command -v "$cmd" >/dev/null 2>&1; then
@@ -22,11 +22,27 @@ if ((${#missing[@]})); then
     printf 'Warning: missing dependencies: %s\n' "${missing[*]}"
 fi
 
+DIRS=(alacritty hypr waybar wofi)
+
+progress() {
+    local current=$1 total=$2 width=30
+    local percent=$(( current * 100 / total ))
+    local filled=$(( current * width / total ))
+    local bar
+    bar=$(printf "%${filled}s" | tr ' ' '#')
+    printf '\r[%-*s] %d%%' "$width" "$bar" "$percent"
+}
+
 mkdir -p "$CONFIG_DEST"
-for dir in alacritty hypr waybar wofi; do
+total=${#DIRS[@]}
+step=0
+progress $step $total
+for dir in "${DIRS[@]}"; do
     rm -rf "$CONFIG_DEST/$dir"
     cp -r ".config/$dir" "$CONFIG_DEST/"
-    printf 'Installed %s configuration.\n' "$dir"
+    step=$((step+1))
+    progress $step $total
+    printf '\nInstalled %s configuration.\n' "$dir"
 done
 
-echo 'HyprRice installation complete.'
+echo -e '\nHyprRice installation complete.'

--- a/install_gui.sh
+++ b/install_gui.sh
@@ -5,7 +5,7 @@ sudo pacman -S --needed \
   networkmanager network-manager-applet nm-connection-editor \
   polkit-gnome bluez bluez-utils blueman \
   pavucontrol helvum xfce4-power-manager udiskie \
-  nwg-displays waybar && \
+  nwg-displays waybar alacritty swaybg wofi firefox dolphin hyprland && \
 paru -S --needed hyprgui-git && \
 systemctl enable --now NetworkManager bluetooth && \
 hyprctl reload


### PR DESCRIPTION
## Summary
- Fix Super+Enter binding by using Return so Hyprland launches the terminal properly
- Replace Waybar icons with fixed-width ASCII progress bars and detailed tooltips
- Expand install scripts with additional packages and text progress indicators

## Testing
- `bash -n install.sh`
- `bash -n install_gui.sh`
- `jq empty .config/waybar/config`


------
https://chatgpt.com/codex/tasks/task_e_688e21ebc0dc8330b4f885ff31c04e92