### PR TITLE
Guard Hyprland commands against missing programs

### DIFF
--- a/.config/hypr/hyprland.conf
+++ b/.config/hypr/hyprland.conf
@@ -27,7 +27,7 @@ gaps_in  = 4    # small gap between windows (helps separate double borders)
 gaps_out = 0    # no outer gap (windows touch screen edges, bar will reserve space)
 
 # Set wallpaper to black (solid color)
-exec-once = swaybg -c "#000000"   # requires swaybg installed; fills background with black
+exec-once = sh -c 'command -v swaybg >/dev/null 2>&1 && swaybg -c "#000000" &'   # launch background only if swaybg is available
 
 ## ── Keybindings ─────────────────────────────
 # Format: bind = MOD, key, action, argument
@@ -38,10 +38,10 @@ bind = $mainMod, C, togglefloating  # Super+C toggles floating (detach/attach)
 # Super+V: float, center and resize the window
 bind = $mainMod, V, exec, sh -c 'hyprctl dispatch togglefloating; hyprctl dispatch centerwindow; hyprctl dispatch resizewindowpixel exact 1600 900'
 
-bind = $mainMod, F, exec, dolphin    # Super+F launches Dolphin file manager
-bind = $mainMod, B, exec, firefox    # Super+B launches Firefox browser
-bind = $mainMod, Return, exec, alacritty  # Super+Enter opens Alacritty terminal
-bind = $mainMod, Space, exec, wofi --show drun   # Super+Space opens Wofi launcher (drun mode)
+bind = $mainMod, F, exec, sh -c 'command -v dolphin >/dev/null 2>&1 && dolphin'    # Super+F launches Dolphin if installed
+bind = $mainMod, B, exec, sh -c 'command -v firefox >/dev/null 2>&1 && firefox'    # Super+B launches Firefox if installed
+bind = $mainMod, Return, exec, sh -c 'command -v alacritty >/dev/null 2>&1 && alacritty'  # Super+Enter opens Alacritty if installed
+bind = $mainMod, Space, exec, sh -c 'command -v wofi >/dev/null 2>&1 && wofi --show drun'   # Super+Space opens Wofi if installed
 
 # Window focus navigation (arrow keys to move focus)
 bind = $mainMod, Left,  movefocus, l
@@ -75,16 +75,16 @@ windowrule = center, class:Wofi             # center wofi on screen (respect res
 # e.g., for Electron apps or GTK apps one might set environment variables (not needed for Dolphin)
 
 ## ── Autostart (exec-once) ───────────────────
-exec-once = waybar &          # start Waybar (status bar)
-exec-once = alacritty &       # launch a terminal at startup (so user has a shell open)
+exec-once = sh -c 'command -v waybar >/dev/null 2>&1 && waybar &'          # start Waybar if available
+exec-once = sh -c 'command -v alacritty >/dev/null 2>&1 && alacritty &'       # launch a terminal at startup if available
 
 #######################################
 #  helpers & tray items (Matrix-style)
 #######################################
-exec-once = /usr/lib/polkit-gnome/polkit-gnome-authentication-agent-1 &
-exec-once = nm-applet --indicator &
-exec-once = blueman-applet &
-exec-once = udiskie &
+exec-once = sh -c '[ -x /usr/lib/polkit-gnome/polkit-gnome-authentication-agent-1 ] && /usr/lib/polkit-gnome/polkit-gnome-authentication-agent-1 &'  # start polkit agent if present
+exec-once = sh -c 'command -v nm-applet >/dev/null 2>&1 && nm-applet --indicator &'   # start network manager applet if installed
+exec-once = sh -c 'command -v blueman-applet >/dev/null 2>&1 && blueman-applet &'     # start Bluetooth applet if installed
+exec-once = sh -c 'command -v udiskie >/dev/null 2>&1 && udiskie &'                   # start udiskie if installed
 
 # NOTE: Ensure Waybar and Wofi are installed. Wofi does not run as daemon; it's launched via keybind.
 # The above commands with '&' run them in background so Hyprland can continue startup.


### PR DESCRIPTION
## Summary
- avoid "does not exist" errors by running Hyprland exec/Autostart commands only if the program is installed

## Testing
- `sh -n -c 'command -v swaybg >/dev/null 2>&1 && swaybg -c "#000000" &'`
- `sh -n -c 'command -v dolphin >/dev/null 2>&1 && dolphin'`
- `sh -n -c 'command -v waybar >/dev/null 2>&1 && waybar &'`
- `sh -n -c '[ -x /usr/lib/polkit-gnome/polkit-gnome-authentication-agent-1 ] && /usr/lib/polkit-gnome/polkit-gnome-authentication-agent-1 &'`
- `hyprctl --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e25034c248330b945a0f80a666e6b