### PR TITLE
fix: clean up hyprland decoration settings

### DIFF
--- a/.config/hypr/hyprland.conf
+++ b/.config/hypr/hyprland.conf
@@ -10,8 +10,9 @@ decoration {
     drop_shadow = false
     active_opacity = 1.0
     inactive_opacity = 1.0
-    blur = false
-    shadow_range = 0
+    blur {
+        enabled = false
+    }
 }
 
 general {


### PR DESCRIPTION
## Summary
- remove deprecated shadow config
- nest blur settings under `decoration` to properly disable it

## Testing
- `hyprctl --version` *(fails: command not found)*
- `sudo apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_688e2db8c3d08330909ba336388d628d