### PR TITLE
Add centered floating zoom mode and plain text Waybar

### DIFF
--- a/.config/hypr/hyprland.conf
+++ b/.config/hypr/hyprland.conf
@@ -17,7 +17,7 @@ decoration {
 
 general {
     gaps_in = 2
-    gaps_out = 0
+    gaps_out = 5,0,0,0
     border_size = 2
     col.active_border = rgba(0,255,0,1)
     col.inactive_border = rgba(0,255,0,0.5)
@@ -47,7 +47,7 @@ bind = SUPER, SPACE, exec, wofi --show drun
 bind = SUPER, Q, killactive
 bind = SUPER, F, exec, dolphin
 bind = SUPER, B, exec, firefox
-bind = SUPER, C, togglefloating
+bind = SUPER, C, exec, ~/.config/hypr/scripts/center-float-zoom.sh
 bind = SUPER, V, centerwindow
 
 # Move focus

--- a/.config/hypr/scripts/center-float-zoom.sh
+++ b/.config/hypr/scripts/center-float-zoom.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Toggle centered floating zoomed window
+set -euo pipefail
+active=$(hyprctl -j activewindow 2>/dev/null)
+[ -z "$active" ] && exit 0
+floating=$(echo "$active" | jq -r '.floating')
+if [ "$floating" = "false" ]; then
+    mon=$(echo "$active" | jq -r '.monitor')
+    minfo=$(hyprctl -j monitors | jq -r ".[] | select(.name==\"$mon\")")
+    width=$(echo "$minfo" | jq '.width')
+    height=$(echo "$minfo" | jq '.height')
+    neww=$((width * 8 / 10))
+    newh=$((height * 8 / 10))
+    hyprctl dispatch togglefloating
+    hyprctl dispatch resizeactive exact "$neww" "$newh"
+    hyprctl dispatch centerwindow
+else
+    hyprctl dispatch togglefloating
+fi

--- a/.config/waybar/config
+++ b/.config/waybar/config
@@ -7,7 +7,7 @@
   },
   "modules-left": ["workspaces"],
   "modules-center": ["clock"],
-  "modules-right": ["pulseaudio", "network", "cpu", "memory", "tray"],
+  "modules-right": ["pulseaudio", "network", "cpu", "memory", "battery", "tray"],
   "clock": {
     "format": "{:%Y-%m-%d %H:%M}",
     "tooltip": true,
@@ -15,25 +15,32 @@
   },
   "pulseaudio": {
     "tooltip": true,
-    "format": "{volume}% ",
+    "format": "Audio: {volume}%",
     "on-click": "pavucontrol"
   },
   "network": {
     "tooltip": true,
-    "format-wifi": "{signalStrength}% ",
-    "format-ethernet": "{ipaddr} ",
+    "format-wifi": "Net: {signalStrength}%",
+    "format-ethernet": "Net: {ipaddr}",
+    "format-disconnected": "Net: down",
     "on-click": "alacritty -e nmtui"
   },
   "cpu": {
     "tooltip": true,
-    "format": "{usage}% "
+    "format": "CPU: {usage}%"
   },
   "memory": {
     "tooltip": true,
-    "format": "{used}G/{total}G "
+    "format": "Mem: {used}G/{total}G"
+  },
+  "battery": {
+    "tooltip": true,
+    "format": "Power: {capacity}%",
+    "format-charging": "Power: {capacity}%+",
+    "format-full": "Power: full"
   },
   "workspaces": {
     "tooltip": true,
-    "format": "{icon}"
+    "format": "{name}"
   }
 }

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ HyprRice is a matrix-inspired configuration for the [Hyprland](https://github.co
 - Neon green "Matrix" theme with solid active/inactive borders
 - Zero window rounding and no shadows for a crisp aesthetic
 - Animations disabled for snappy performance
-- Small inner gaps for tiling and no outer gaps
+- Small inner gaps for tiling and a minimal top gap for Waybar
 - Waybar for system status and Wofi as application launcher
 - Waybar modules show tooltips and launch pavucontrol or NetworkManager when clicked
 - Autostarts Waybar and an Alacritty terminal
@@ -42,8 +42,8 @@ HyprRice is a matrix-inspired configuration for the [Hyprland](https://github.co
 | **Super + Q** | Close focused window |
 | **Super + F** | Launch Dolphin file manager |
 | **Super + B** | Launch Firefox browser |
-| **Super + C** | Toggle floating mode |
-| **Super + V** | Center and widen window for easy moving |
+| **Super + C** | Toggle centered floating zoom |
+| **Super + V** | Center window |
 | **Super + Arrow Keys** | Move focus left/down/up/right |
 | **Super + Ctrl + Arrow Keys** | Move window to adjacent workspace |
 | **Super + [1-9]** | Switch to workspace 1-9 |

--- a/install.sh
+++ b/install.sh
@@ -11,7 +11,7 @@ CONFIG_DEST="$TARGET_HOME/.config"
 printf 'Installing configuration for user %s in %s\n' "$TARGET_USER" "$CONFIG_DEST"
 
 # Ensure required packages are installed
-needed=(alacritty hyprland waybar wofi swaybg dolphin firefox pavucontrol networkmanager)
+needed=(alacritty hyprland waybar wofi swaybg dolphin firefox pavucontrol networkmanager jq)
 missing=()
 for cmd in "${needed[@]}"; do
     if ! command -v "$cmd" >/dev/null 2>&1; then

--- a/install_gui.sh
+++ b/install_gui.sh
@@ -5,7 +5,7 @@ sudo pacman -S --needed \
   networkmanager network-manager-applet nm-connection-editor \
   polkit-gnome bluez bluez-utils blueman \
   pavucontrol helvum xfce4-power-manager udiskie \
-  nwg-displays waybar alacritty swaybg wofi firefox dolphin hyprland && \
+  nwg-displays waybar alacritty swaybg wofi firefox dolphin hyprland jq && \
 paru -S --needed hyprgui-git && \
 systemctl enable --now NetworkManager bluetooth && \
 hyprctl reload

--- a/update.sh
+++ b/update.sh
@@ -9,7 +9,7 @@ CONFIG_DEST="$TARGET_HOME/.config"
 DIRS=(alacritty hypr waybar wofi)
 
 # Ensure required packages are installed
-needed=(alacritty hyprland waybar wofi swaybg dolphin firefox pavucontrol networkmanager)
+needed=(alacritty hyprland waybar wofi swaybg dolphin firefox pavucontrol networkmanager jq)
 missing=()
 for cmd in "${needed[@]}"; do
     if ! command -v "$cmd" >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- Add script and binding for Super+C centered floating zoom
- Use ASCII labels in Waybar with battery module and no icons
- Add top gap under Waybar and document updated keybinds; include jq dependency in install scripts

## Testing
- `jq empty .config/waybar/config`
- `bash -n install.sh update.sh install_gui.sh .config/hypr/scripts/center-float-zoom.sh`
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_688e3403f0f08330989155ec91ff9bb9