### PR TITLE
Improve waybar labels and workspace animations

### DIFF
--- a/.config/hypr/hyprland.conf
+++ b/.config/hypr/hyprland.conf
@@ -1,8 +1,14 @@
 # HyprRice Hyprland configuration
 
-# Disable animations and shadows for snappy performance and clean look
+# Enable fast sliding workspace animation only
 animations {
-    enabled = false
+    enabled = true
+    animation = windows, 0, 0, default
+    animation = fade, 0, 0, default
+    animation = border, 0, 0, default
+    animation = borderangle, 0, 0, default
+    animation = shadow, 0, 0, default
+    animation = workspaces, 1, 7, default, slide
 }
 
 decoration {

--- a/.config/waybar/config
+++ b/.config/waybar/config
@@ -8,39 +8,58 @@
   "modules-left": ["workspaces"],
   "modules-center": ["clock"],
   "modules-right": ["pulseaudio", "network", "cpu", "memory", "battery", "tray"],
+
   "clock": {
     "format": "{:%Y-%m-%d %H:%M}",
     "tooltip": true,
+    "tooltip-format": "{:%A, %B %d %Y}",
     "on-click": "alacritty -e cal"
   },
+
   "pulseaudio": {
+    "format": " VOL {volume}%",
+    "format-muted": " VOL {volume}%",
     "tooltip": true,
-    "format": "Audio: {volume}%",
+    "tooltip-format": "Volume: {volume}%",
     "on-click": "pavucontrol"
   },
+
   "network": {
+    "format-wifi": " NET {signalStrength}%",
+    "format-ethernet": " NET {ipaddr}",
+    "format-disconnected": " NET down",
     "tooltip": true,
-    "format-wifi": "Net: {signalStrength}%",
-    "format-ethernet": "Net: {ipaddr}",
-    "format-disconnected": "Net: down",
-    "on-click": "alacritty -e nmtui"
+    "tooltip-format": "SSID: {essid}\nSignal: {signalStrength}%\nIP: {ipaddr}",
+    "on-click": "nm-connection-editor"
   },
+
   "cpu": {
+    "format": " CPU {usage}%",
     "tooltip": true,
-    "format": "CPU: {usage}%"
+    "tooltip-format": "CPU usage: {usage}%"
   },
+
   "memory": {
+    "format": " MEM {used}G/{total}G",
     "tooltip": true,
-    "format": "Mem: {used}G/{total}G"
+    "tooltip-format": "Memory used: {used}G / {total}G"
   },
+
   "battery": {
+    "format": " BAT {capacity}%",
+    "format-charging": " BAT {capacity}%",
+    "format-full": " BAT full",
     "tooltip": true,
-    "format": "Power: {capacity}%",
-    "format-charging": "Power: {capacity}%+",
-    "format-full": "Power: full"
+    "tooltip-format": "Battery: {capacity}%"
   },
+
   "workspaces": {
+    "format": "{id}",
+    "sort-by-number": true,
+    "on-scroll-up": "hyprctl dispatch workspace -1",
+    "on-scroll-down": "hyprctl dispatch workspace +1",
+    "on-click": "hyprctl dispatch workspace {id}",
     "tooltip": true,
-    "format": "{name}"
+    "tooltip-format": "Workspace {id}: {windows} windows"
   }
 }

--- a/.config/waybar/style.css
+++ b/.config/waybar/style.css
@@ -8,7 +8,12 @@ window#waybar {
   color: #00ff00;
 }
 
-#workspaces button.focused {
+#workspaces button {
+  padding: 0 4px;
+  background: transparent;
+}
+
+#workspaces button.active {
   background: #005500;
 }
 


### PR DESCRIPTION
## Summary
- add icon labels and detailed tooltips to waybar modules
- open nm-connection-editor from waybar network module
- enable fast sliding workspace transitions in Hyprland and style workspaces in Waybar

## Testing
- `jq empty .config/waybar/config`


------
https://chatgpt.com/codex/tasks/task_e_688e379dc87483308153a118968bfa6c