### PR TITLE
Add disk module to Waybar and ensure script dependencies

### DIFF
--- a/.config/waybar/config
+++ b/.config/waybar/config
@@ -8,7 +8,7 @@
   },
   "modules-left": ["workspaces"],
   "modules-center": ["clock"],
-  "modules-right": ["pulseaudio", "network", "cpu", "memory", "battery", "tray"],
+  "modules-right": ["pulseaudio", "network", "cpu", "memory", "disk", "battery", "tray"],
 
   "clock": {
     "format": "{:%Y-%m-%d %H:%M}",
@@ -37,13 +37,23 @@
   "cpu": {
     "format": " CPU {usage}%",
     "tooltip": true,
-    "tooltip-format": "CPU usage: {usage}%"
+    "tooltip-format": "CPU usage: {usage}%",
+    "on-click": "alacritty -e htop"
   },
 
   "memory": {
     "format": " MEM {used}G/{total}G",
     "tooltip": true,
-    "tooltip-format": "Memory used: {used}G / {total}G"
+    "tooltip-format": "Memory used: {used}G / {total}G",
+    "on-click": "alacritty -e htop"
+  },
+
+  "disk": {
+    "format": " DISK {percentage_used}%",
+    "path": "/",
+    "tooltip": true,
+    "tooltip-format": "{used} / {total} used",
+    "on-click": "alacritty -e ncdu /"
   },
 
   "battery": {
@@ -51,7 +61,8 @@
     "format-charging": " BAT {capacity}%",
     "format-full": " BAT full",
     "tooltip": true,
-    "tooltip-format": "Battery: {capacity}%"
+    "tooltip-format": "Battery: {capacity}%",
+    "on-click": "xfce4-power-manager-settings"
   },
 
   "workspaces": {

--- a/install.sh
+++ b/install.sh
@@ -11,7 +11,22 @@ CONFIG_DEST="$TARGET_HOME/.config"
 printf 'Installing configuration for user %s in %s\n' "$TARGET_USER" "$CONFIG_DEST"
 
 # Ensure required packages are installed
-needed=(alacritty hyprland waybar wofi swaybg dolphin firefox pavucontrol networkmanager jq)
+needed=(
+    alacritty
+    hyprland
+    waybar
+    wofi
+    swaybg
+    dolphin
+    firefox
+    pavucontrol
+    networkmanager
+    nm-connection-editor
+    xfce4-power-manager-settings
+    htop
+    ncdu
+    jq
+)
 missing=()
 for cmd in "${needed[@]}"; do
     if ! command -v "$cmd" >/dev/null 2>&1; then

--- a/install_gui.sh
+++ b/install_gui.sh
@@ -5,7 +5,7 @@ sudo pacman -S --needed \
   networkmanager network-manager-applet nm-connection-editor \
   polkit-gnome bluez bluez-utils blueman \
   pavucontrol helvum xfce4-power-manager udiskie \
-  nwg-displays waybar alacritty swaybg wofi firefox dolphin hyprland jq && \
+  nwg-displays waybar alacritty swaybg wofi firefox dolphin hyprland jq htop ncdu && \
 paru -S --needed hyprgui-git && \
 systemctl enable --now NetworkManager bluetooth && \
 hyprctl reload

--- a/update.sh
+++ b/update.sh
@@ -9,7 +9,22 @@ CONFIG_DEST="$TARGET_HOME/.config"
 DIRS=(alacritty hypr waybar wofi)
 
 # Ensure required packages are installed
-needed=(alacritty hyprland waybar wofi swaybg dolphin firefox pavucontrol networkmanager jq)
+needed=(
+    alacritty
+    hyprland
+    waybar
+    wofi
+    swaybg
+    dolphin
+    firefox
+    pavucontrol
+    networkmanager
+    nm-connection-editor
+    xfce4-power-manager-settings
+    htop
+    ncdu
+    jq
+)
 missing=()
 for cmd in "${needed[@]}"; do
     if ! command -v "$cmd" >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- Add disk space module to Waybar and wire CPU, memory, and battery widgets to helper tools
- Ensure all modules have corresponding packages in install and update scripts
- Include htop and ncdu in GUI package installer

## Testing
- `bash -n install.sh install_gui.sh update.sh`
- `jq empty .config/waybar/config`


------
https://chatgpt.com/codex/tasks/task_e_688e42efd1748330930036cb357bc5f0