### PR TITLE
Add Hyprland keybindings, dependencies, and validation script

### DIFF
--- a/.config/hypr/hyprland.conf
+++ b/.config/hypr/hyprland.conf
@@ -125,3 +125,17 @@ bind = , Print, exec, grim "$HOME/Pictures/Screenshots/$(date +'%Y-%m-%d-%H%M%S'
 bind = $mainMod, S, exec, grim -g "$(slurp)" - | swappy -f -
 bind = ALT, TAB, cyclenext
 bind = ALT SHIFT, TAB, cycleprev
+
+# Additional keybindings
+bind = $mainMod, Y, pin
+bind = $mainMod, K, togglegroup
+bind = $mainMod, PERIOD, workspace, +1
+bind = $mainMod, COMMA, workspace, -1
+bind = $mainMod, O, exec, pkill -SIGUSR2 waybar
+bind = $mainMod, G, exec, hyprctl keyword general:gaps_in 0 && hyprctl keyword general:gaps_out "0 0 0 0"
+bind = $mainMod SHIFT, G, exec, hyprctl keyword general:gaps_in 2 && hyprctl keyword general:gaps_out "5 0 0 0"
+bind = $mainMod CTRL SHIFT, LEFT, resizeactive, -50 0
+bind = $mainMod CTRL SHIFT, RIGHT, resizeactive, 50 0
+bind = $mainMod CTRL SHIFT, UP, resizeactive, 0 -50
+bind = $mainMod CTRL SHIFT, DOWN, resizeactive, 0 50
+bind = CTRL ALT, DELETE, exit

--- a/install.sh
+++ b/install.sh
@@ -11,6 +11,7 @@ CONFIG_DEST="$TARGET_HOME/.config"
 printf 'Installing configuration for user %s in %s\n' "$TARGET_USER" "$CONFIG_DEST"
 
 # Ensure required packages are installed
+# Added swappy for screenshot annotation and xorg-xwayland for X11 support
 packages=(
     alacritty
     archlinux-xdg-menu
@@ -36,6 +37,7 @@ packages=(
     polkit-gnome
     power-profiles-daemon
     slurp
+    swappy
     swaybg
     swayidle
     swaylock
@@ -50,6 +52,7 @@ packages=(
     xdg-desktop-portal-hyprland
     xfce4-power-manager
     xfce4-settings
+    xorg-xwayland
 )
 if command -v pacman >/dev/null 2>&1; then
     missing=()

--- a/update.sh
+++ b/update.sh
@@ -9,6 +9,7 @@ CONFIG_DEST="$TARGET_HOME/.config"
 DIRS=(alacritty hypr waybar wofi)
 
 # Ensure required packages are installed
+# Added swappy for screenshot annotation and xorg-xwayland for X11 support
 packages=(
     alacritty
     archlinux-xdg-menu
@@ -34,6 +35,7 @@ packages=(
     polkit-gnome
     power-profiles-daemon
     slurp
+    swappy
     swaybg
     swayidle
     swaylock
@@ -48,6 +50,7 @@ packages=(
     xdg-desktop-portal-hyprland
     xfce4-power-manager
     xfce4-settings
+    xorg-xwayland
 )
 if command -v pacman >/dev/null 2>&1; then
     missing=()

--- a/validate.sh
+++ b/validate.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# Validation script for HyprRice configuration
+set -uo pipefail
+
+RED='\e[31m'
+GREEN='\e[32m'
+YELLOW='\e[33m'
+BLUE='\e[34m'
+BOLD='\e[1m'
+RESET='\e[0m'
+
+errors=0
+
+REPO_DIR="$(cd "$(dirname "$0")" && pwd)"
+CONFIG_DIR="$REPO_DIR/.config"
+HYPR_CONF="$CONFIG_DIR/hypr/hyprland.conf"
+WAYBAR_CONF="$CONFIG_DIR/waybar/config"
+
+echo -e "${BLUE}Checking Hyprland config syntax...${RESET}"
+if [[ ! -f "$HYPR_CONF" ]]; then
+    echo -e "Hyprland config ${RED}[ERROR]${RESET}: file not found at $HYPR_CONF"
+    errors=$((errors+1))
+else
+    open_braces=$(grep -o '{' "$HYPR_CONF" | wc -l)
+    close_braces=$(grep -o '}' "$HYPR_CONF" | wc -l)
+    if [[ $open_braces -ne $close_braces ]]; then
+        echo -e "Brace balance ${RED}[ERROR]${RESET}: {=$open_braces }=$close_braces"
+        errors=$((errors+1))
+    else
+        echo -e "Brace balance ${GREEN}[OK]${RESET}"
+    fi
+
+    bad_binds=$(grep '^bind\s*=\s*' "$HYPR_CONF" | while read -r line; do
+        fields=$(awk -F',' '{print NF}' <<<"$line")
+        if ((fields<3 || fields>4)); then
+            echo "$line"
+        fi
+    done)
+    if [[ -n "$bad_binds" ]]; then
+        echo -e "Keybinding format ${RED}[ERROR]${RESET}:" && echo "$bad_binds"
+        errors=$((errors+1))
+    else
+        echo -e "Keybinding format ${GREEN}[OK]${RESET}"
+    fi
+fi
+
+echo -e "${BLUE}Checking Hyprland exec commands...${RESET}"
+if [[ -f "$HYPR_CONF" ]]; then
+    declare -A seen
+    missing_execs=()
+    while read -r line; do
+        cmd=$(echo "$line" | sed 's/^exec-once *= *//' | awk '{print $1}')
+        if [[ "$cmd" == /* ]]; then
+            [[ -x "$cmd" ]] || missing_execs+=("$cmd")
+        else
+            command -v "$cmd" >/dev/null 2>&1 || missing_execs+=("$cmd")
+        fi
+        if [[ "$line" == *"swaylock"* ]]; then
+            command -v swaylock >/dev/null 2>&1 || missing_execs+=("swaylock")
+        fi
+    done < <(grep '^exec-once' "$HYPR_CONF")
+
+    unique_missing=()
+    for m in "${missing_execs[@]}"; do
+        [[ -n ${seen[$m]:-} ]] || { unique_missing+=("$m"); seen[$m]=1; }
+    done
+    if ((${#unique_missing[@]})); then
+        echo -e "Exec commands ${RED}[ERROR]${RESET}: ${unique_missing[*]}"
+        errors=$((errors+1))
+    else
+        echo -e "Exec commands ${GREEN}[OK]${RESET}"
+    fi
+fi
+
+echo -e "${BLUE}Validating Waybar config...${RESET}"
+if command -v jq >/dev/null 2>&1; then
+    if jq empty "$WAYBAR_CONF" >/dev/null 2>&1; then
+        echo -e "Waybar JSON ${GREEN}[OK]${RESET}"
+    else
+        echo -e "Waybar JSON ${RED}[ERROR]${RESET}"
+        errors=$((errors+1))
+    fi
+else
+    echo -e "${YELLOW}[WARN]${RESET} jq not found; skipping Waybar JSON validation"
+fi
+
+WAYBAR_CMDS=(gsimplecal pavucontrol nm-connection-editor alacritty htop ncdu xfce4-power-manager-settings)
+missing_waybar=()
+for cmd in "${WAYBAR_CMDS[@]}"; do
+    command -v "$cmd" >/dev/null 2>&1 || missing_waybar+=("$cmd")
+done
+if ((${#missing_waybar[@]})); then
+    echo -e "Waybar commands ${RED}[ERROR]${RESET}: ${missing_waybar[*]}"
+    errors=$((errors+1))
+else
+    echo -e "Waybar commands ${GREEN}[OK]${RESET}"
+fi
+
+echo -e "${BLUE}Checking required packages...${RESET}"
+packages=(
+    alacritty archlinux-xdg-menu bluez bluez-utils blueman brightnessctl desktop-file-utils firefox grim gvfs gsimplecal htop hyprland jq ncdu networkmanager network-manager-applet nm-connection-editor nwg-look pamixer pavucontrol polkit-gnome power-profiles-daemon slurp swappy swaybg swayidle swaylock swaync thunar ttf-font-awesome ttf-jetbrains-mono-nerd waybar wlogout wofi xdg-desktop-portal xdg-desktop-portal-hyprland xfce4-power-manager xfce4-settings xorg-xwayland
+)
+if command -v pacman >/dev/null 2>&1; then
+    missing_pkgs=()
+    for pkg in "${packages[@]}"; do
+        pacman -Qi "$pkg" >/dev/null 2>&1 || missing_pkgs+=("$pkg")
+    done
+    if ((${#missing_pkgs[@]})); then
+        echo -e "Package check ${RED}[ERROR]${RESET}: ${missing_pkgs[*]}"
+        errors=$((errors+1))
+    else
+        echo -e "Package check ${GREEN}[OK]${RESET}"
+    fi
+else
+    echo -e "${YELLOW}[WARN]${RESET} pacman not found; skipping package check"
+fi
+
+echo -e "${BLUE}Scanning Hyprland logs...${RESET}"
+log_file="$HOME/.cache/hyprland/hyprland.log"
+if [[ -f "$log_file" ]]; then
+    log_lines=$(grep -iE 'error|warning' "$log_file")
+    if [[ -n "$log_lines" ]]; then
+        while IFS= read -r l; do
+            echo -e "${BLUE}[LOG]${RESET} $l"
+        done <<<"$log_lines"
+    else
+        echo -e "Log scan ${GREEN}[OK]${RESET}"
+    fi
+else
+    echo -e "${YELLOW}[WARN]${RESET} No Hyprland log found at $log_file"
+fi
+
+if ((errors>0)); then
+    echo -e "${RED}${BOLD}Validation completed with errors.${RESET}"
+    exit 1
+else
+    echo -e "${GREEN}${BOLD}All checks passed.${RESET}"
+    exit 0
+fi
+


### PR DESCRIPTION
## Summary
- expand Hyprland configuration with CachyOS-inspired keybindings for pinning, workspace navigation, grouping, gap toggles, window resizing, Waybar reload, and session exit
- include swappy and xorg-xwayland in install/update scripts for screenshot annotations and X11 app support
- add validate.sh script to verify config syntax, dependencies, and environment

## Testing
- `bash -n install.sh update.sh validate.sh`
- `./validate.sh` *(fails: swaybg /usr/lib/polkit-gnome/polkit-gnome-authentication-agent-1 nm-applet xfce4-power-manager blueman-applet swaync swayidle swaylock waybar; gsimplecal pavucontrol nm-connection-editor alacritty htop ncdu xfce4-power-manager-settings; pacman not found; no Hyprland log)*

------
https://chatgpt.com/codex/tasks/task_e_688ee39daa108330802015cc2cc81eea