### PR TITLE
feat: add greetd login manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
    cd HyprRice
    ./install.sh
    ```
-   The script installs required packages and copies the configuration into `~/.config` for the current user.
+   The script installs required packages, configures the `greetd` login manager and copies the configuration into `~/.config` for the current user.
 
 ### Packages installed
 
@@ -25,6 +25,8 @@ The install and update scripts ensure the following packages are present:
 - grim
 - gvfs
 - gsimplecal
+- greetd
+- greetd-tuigreet
 - htop
 - hyprland
 - jq
@@ -52,6 +54,10 @@ The install and update scripts ensure the following packages are present:
 - xdg-desktop-portal-hyprland
 - xfce4-power-manager
 - xfce4-settings
+
+On reboot you'll see a neon green `greetd` prompt. After authenticating, Hyprland starts automatically.
+
+The installer attempts to grab the `tuigreet` greeter from the official repositories and falls back to `greetd-tuigreet-bin` via `yay` or `paru`. If no AUR helper is detected you'll need to install the greeter manually.
 
 ## Update
 
@@ -103,7 +109,7 @@ HyprRice is a matrix-inspired configuration for the [Hyprland](https://github.co
 
 ## Notes
 
-The install script installs all required packages including a polkit agent, notification daemon, and NetworkManager.
+The install script installs all required packages including a polkit agent, notification daemon, NetworkManager, and the `greetd` login manager.
 
 ## Waybar Actions
 

--- a/update.sh
+++ b/update.sh
@@ -22,6 +22,8 @@ packages=(
     grim
     gvfs
     gsimplecal
+    greetd
+    greetd-tuigreet
     htop
     hyprland
     jq
@@ -54,13 +56,33 @@ packages=(
 )
 if command -v pacman >/dev/null 2>&1; then
     missing=()
+    aur_missing=()
     for pkg in "${packages[@]}"; do
-        pacman -Qi "$pkg" >/dev/null 2>&1 || missing+=("$pkg")
+        if pacman -Qi "$pkg" >/dev/null 2>&1; then
+            continue
+        elif pacman -Si "$pkg" >/dev/null 2>&1; then
+            missing+=("$pkg")
+        else
+            aur_missing+=("$pkg")
+        fi
     done
     if ((${#missing[@]})); then
         printf 'Installing missing dependencies: %s\n' "${missing[*]}"
         sudo pacman -S --needed --noconfirm "${missing[@]}"
     fi
+    for pkg in "${aur_missing[@]}"; do
+        case "$pkg" in
+            greetd-tuigreet) aur_pkg="greetd-tuigreet-bin";;
+            *) aur_pkg="$pkg";;
+        esac
+        if command -v yay >/dev/null 2>&1; then
+            yay -S --needed --noconfirm "$aur_pkg" || true
+        elif command -v paru >/dev/null 2>&1; then
+            paru -S --needed --noconfirm "$aur_pkg" || true
+        else
+            printf 'Please install %s manually from the AUR.\n' "$aur_pkg"
+        fi
+    done
 else
     printf 'Warning: pacman not found; cannot verify dependencies.\n'
 fi
@@ -77,6 +99,19 @@ if command -v systemctl >/dev/null 2>&1; then
     sudo systemctl enable --now bluetooth.service || true
     sudo systemctl enable --now power-profiles-daemon.service || true
     sudo -u "$TARGET_USER" systemctl --user restart xdg-desktop-portal-hyprland.service || true
+    sudo systemctl enable greetd.service || true
+fi
+
+if command -v sudo >/dev/null 2>&1; then
+    sudo mkdir -p /etc/greetd
+    sudo tee /etc/greetd/config.toml >/dev/null <<'EOF'
+[terminal]
+vt = 1
+
+[default_session]
+command = "tuigreet --time --user-menu --cmd Hyprland --theme 'text=green;prompt=green;input=green;container=black;border=green;title=green;action=green;button=green'"
+user = "greeter"
+EOF
 fi
 
 progress() {

--- a/validate.sh
+++ b/validate.sh
@@ -98,7 +98,7 @@ fi
 
 echo -e "${BLUE}Checking required packages...${RESET}"
 packages=(
-    alacritty archlinux-xdg-menu bluez bluez-utils blueman brightnessctl desktop-file-utils firefox grim gvfs gsimplecal htop hyprland jq ncdu networkmanager network-manager-applet nm-connection-editor nwg-look pamixer pavucontrol polkit-gnome power-profiles-daemon slurp swappy swaybg swayidle swaylock swaync thunar ttf-font-awesome ttf-jetbrains-mono-nerd waybar wlogout wofi xdg-desktop-portal xdg-desktop-portal-hyprland xfce4-power-manager xfce4-settings xorg-xwayland
+    alacritty archlinux-xdg-menu bluez bluez-utils blueman brightnessctl desktop-file-utils firefox grim gvfs gsimplecal greetd greetd-tuigreet htop hyprland jq ncdu networkmanager network-manager-applet nm-connection-editor nwg-look pamixer pavucontrol polkit-gnome power-profiles-daemon slurp swappy swaybg swayidle swaylock swaync thunar ttf-font-awesome ttf-jetbrains-mono-nerd waybar wlogout wofi xdg-desktop-portal xdg-desktop-portal-hyprland xfce4-power-manager xfce4-settings xorg-xwayland
 )
 if command -v pacman >/dev/null 2>&1; then
     missing_pkgs=()


### PR DESCRIPTION
## Summary
- add greetd and tuigreet dependencies with AUR fallback
- configure greetd to launch a Matrix-themed Hyprland session
- document greetd usage and update validation

## Testing
- `./validate.sh` *(fails: missing swaybg, polkit agent, nm-applet, xfce4-power-manager, blueman-applet, swaync, swayidle, swaylock, waybar, gsimplecal, pavucontrol, nm-connection-editor, alacritty, htop, ncdu, xfce4-power-manager-settings; pacman not found; no Hyprland log)*

------
https://chatgpt.com/codex/tasks/task_e_688f0e99e8a4833085fab3aed185dac8