### PR TITLE
Switch to PipeWire audio stack

### DIFF
--- a/.config/hypr/hyprland.conf
+++ b/.config/hypr/hyprland.conf
@@ -115,9 +115,9 @@ bind = $mainMod SHIFT, 8, movetoworkspace, 8
 bind = $mainMod SHIFT, 9, movetoworkspace, 9
 
 # Media keys
-bind = , XF86AudioRaiseVolume, exec, pamixer -i 5
-bind = , XF86AudioLowerVolume, exec, pamixer -d 5
-bind = , XF86AudioMute, exec, pamixer -t
+bind = , XF86AudioRaiseVolume, exec, pulsemixer --change-volume +5
+bind = , XF86AudioLowerVolume, exec, pulsemixer --change-volume -5
+bind = , XF86AudioMute, exec, pulsemixer --toggle-mute
 bind = , XF86MonBrightnessUp, exec, brightnessctl set +10%
 bind = , XF86MonBrightnessDown, exec, brightnessctl set 10%-
 bind = , Print, exec, grim "$HOME/Pictures/Screenshots/$(date +'%Y-%m-%d-%H%M%S').png"

--- a/.config/waybar/config
+++ b/.config/waybar/config
@@ -32,7 +32,7 @@
     "format-muted": " VOL {volume}%",
     "tooltip": true,
     "tooltip-format": "Volume: {volume}%",
-    "on-click": "pavucontrol"
+    "on-click": "alacritty -e pulsemixer"
   },
   "network": {
     "format-wifi": " NET {signalStrength}%",

--- a/README.md
+++ b/README.md
@@ -36,8 +36,12 @@ The install and update scripts ensure the following packages are present:
 - networkmanager
 - nm-connection-editor
 - nwg-look
-- pamixer
-- pavucontrol
+- pipewire
+- pipewire-alsa
+- pipewire-pulse
+- wireplumber
+- alsa-utils
+- pulsemixer
 - polkit-gnome
 - power-profiles-daemon
 - slurp
@@ -79,7 +83,7 @@ HyprRice is a matrix-inspired configuration for the [Hyprland](https://github.co
 - Animations disabled for snappy performance
 - Small inner gaps for tiling and a minimal top gap for Waybar
 - Waybar for system status and Wofi as application launcher
-- Waybar modules show tooltips and launch pavucontrol, NetworkManager, calendar, and power settings when clicked
+- Waybar modules show tooltips and launch pulsemixer, NetworkManager, calendar, and power settings when clicked
 - Autostarts Waybar along with a polkit agent, NetworkManager, Bluetooth, power and notification applets
 - Solid black wallpaper via swaybg
 
@@ -117,7 +121,7 @@ The install script installs all required packages including a polkit agent, noti
 | Module | Click Action |
 |--------|--------------|
 | Clock | Open `gsimplecal` calendar |
-| Audio | Launch `pavucontrol` |
+| Audio | Launch `pulsemixer` |
 | Network | Launch `nm-connection-editor` |
 | Battery | Open `xfce4-power-manager-settings` (provided by `xfce4-power-manager`) |
 | Disk | Launch `ncdu` in Alacritty |

--- a/fix_sound.sh
+++ b/fix_sound.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# fix_sound.sh — purge PulseAudio, enable PipeWire, unmute channels
+
+set -uo pipefail
+RED='\e[31m'; GREEN='\e[32m'; YELLOW='\e[33m'; BOLD='\e[1m'; RESET='\e[0m'
+
+echo -e "${BOLD}${GREEN}▶ HyprRice Audio Repair${RESET}"
+
+## 1) Remove PulseAudio packages
+PA_PKGS=$(pacman -Qq | grep -E '^pulseaudio' || true)
+if [[ -n $PA_PKGS ]]; then
+  echo -e "${YELLOW}Removing PulseAudio packages:${RESET} $PA_PKGS"
+  sudo pacman -Rns --noconfirm $PA_PKGS
+else
+  echo -e "${GREEN}[OK] No PulseAudio packages detected.${RESET}"
+fi
+
+## 2) Ensure PipeWire stack present
+REQ=(pipewire pipewire-pulse pipewire-alsa wireplumber alsa-utils pulsemixer)
+missing=()
+for p in "${REQ[@]}"; do
+  pacman -Qi "$p" &>/dev/null || missing+=("$p")
+done
+if (( ${#missing[@]} )); then
+  echo -e "${YELLOW}Installing:${RESET} ${missing[*]}"
+  sudo pacman -S --noconfirm "${missing[@]}"
+fi
+
+## 3) Enable + start services
+systemctl --user enable --now pipewire pipewire-pulse wireplumber
+
+## 4) Unmute Master/PCM on all cards
+for card in /proc/asound/card?; do
+  idx="${card##*card}"
+  amixer -c "$idx" -q sset Master unmute 100% || true
+  amixer -c "$idx" -q sset PCM    unmute 100% || true
+done
+
+## 5) Quick verification
+sleep 2
+if systemctl --user --quiet is-active pipewire && \
+   systemctl --user --quiet is-active wireplumber; then
+   echo -e "${GREEN}✔ Audio services running.${RESET}"
+else
+   echo -e "${RED}✖ PipeWire services NOT active! Check journalctl --user -u pipewire.${RESET}"
+fi
+
+echo -e "${BOLD}${YELLOW}→ REBOOT NOW to complete audio repair.${RESET}"

--- a/update.sh
+++ b/update.sh
@@ -6,7 +6,19 @@ set -euo pipefail
 TARGET_USER=${SUDO_USER:-${USER:-$(id -un)}}
 TARGET_HOME=$(eval echo "~$TARGET_USER")
 CONFIG_DEST="$TARGET_HOME/.config"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 DIRS=(alacritty hypr waybar wofi)
+
+# Ensure PipeWire audio stack
+if command -v pacman >/dev/null 2>&1; then
+    PA_PKGS=$(pacman -Qq | grep -E '^pulseaudio' || true)
+    if [[ -n $PA_PKGS ]]; then
+        sudo pacman -Rns --noconfirm $PA_PKGS || true
+    fi
+    sudo pacman -S --needed --noconfirm pipewire pipewire-pulse pipewire-alsa wireplumber alsa-utils pulsemixer
+    sudo -u "$TARGET_USER" systemctl --user enable --now pipewire pipewire-pulse wireplumber || true
+    echo -e '\e[1;33mAudio stack switched to PipeWire. You must REBOOT for changes to take full effect.\e[0m'
+fi
 
 # Ensure required packages are installed
 # Added swappy for screenshot annotation and xorg-xwayland for X11 support
@@ -32,8 +44,12 @@ packages=(
     network-manager-applet
     nm-connection-editor
     nwg-look
-    pamixer
-    pavucontrol
+    pipewire
+    pipewire-pulse
+    pipewire-alsa
+    wireplumber
+    alsa-utils
+    pulsemixer
     polkit-gnome
     power-profiles-daemon
     slurp
@@ -148,5 +164,10 @@ for dir in "${DIRS[@]}"; do
     step=$((step+1))
     progress $step $total
 done
+
+# Validate configuration
+if [[ -x "$SCRIPT_DIR/validate.sh" ]]; then
+    sudo -u "$TARGET_USER" "$SCRIPT_DIR/validate.sh"
+fi
 
 echo -e "\nHyprRice update complete."

--- a/validate.sh
+++ b/validate.sh
@@ -16,6 +16,11 @@ CONFIG_DIR="$REPO_DIR/.config"
 HYPR_CONF="$CONFIG_DIR/hypr/hyprland.conf"
 WAYBAR_CONF="$CONFIG_DIR/waybar/config"
 
+echo -e "${BLUE}Auto-formatting Hyprland config...${RESET}"
+if [[ -f "$HYPR_CONF" ]]; then
+    sed -i 's/[ \t]*$//' "$HYPR_CONF"
+fi
+
 echo -e "${BLUE}Checking Hyprland config syntax...${RESET}"
 if [[ ! -f "$HYPR_CONF" ]]; then
     echo -e "Hyprland config ${RED}[ERROR]${RESET}: file not found at $HYPR_CONF"
@@ -87,7 +92,7 @@ fi
 # Commands that Waybar modules rely on. The power manager settings binary is
 # provided by the xfce4-power-manager package, so we check for the package's
 # main command here.
-WAYBAR_CMDS=(gsimplecal pavucontrol nm-connection-editor alacritty htop ncdu xfce4-power-manager)
+WAYBAR_CMDS=(gsimplecal pulsemixer nm-connection-editor alacritty htop ncdu xfce4-power-manager)
 missing_waybar=()
 for cmd in "${WAYBAR_CMDS[@]}"; do
     command -v "$cmd" >/dev/null 2>&1 || missing_waybar+=("$cmd")
@@ -101,7 +106,8 @@ fi
 
 echo -e "${BLUE}Checking required packages...${RESET}"
 packages=(
-    alacritty archlinux-xdg-menu bluez bluez-utils blueman brightnessctl desktop-file-utils firefox grim gvfs gsimplecal greetd greetd-tuigreet htop hyprland jq ncdu networkmanager network-manager-applet nm-connection-editor nwg-look pamixer pavucontrol polkit-gnome power-profiles-daemon slurp swappy swaybg swayidle swaylock swaync thunar ttf-font-awesome ttf-jetbrains-mono-nerd waybar wlogout wofi xdg-desktop-portal xdg-desktop-portal-hyprland xfce4-power-manager xfce4-settings xorg-xwayland
+    alacritty archlinux-xdg-menu bluez bluez-utils blueman brightnessctl desktop-file-utils firefox grim gvfs gsimplecal greetd
+greetd-tuigreet htop hyprland jq ncdu networkmanager network-manager-applet nm-connection-editor nwg-look pipewire pipewire-pulse pipewire-alsa wireplumber alsa-utils pulsemixer polkit-gnome power-profiles-daemon slurp swappy swaybg swayidle swaylock swaync thunar ttf-font-awesome ttf-jetbrains-mono-nerd waybar wlogout wofi xdg-desktop-portal xdg-desktop-portal-hyprland xfce4-power-manager xfce4-settings xorg-xwayland
 )
 if command -v pacman >/dev/null 2>&1; then
     missing_pkgs=()


### PR DESCRIPTION
## Summary
- replace PulseAudio tooling with PipeWire in install/update scripts and configs
- add `fix_sound.sh` repair script
- auto-format and validate Hyprland config after install/update

## Testing
- `./validate.sh` *(fails: Exec commands [ERROR]: swaybg /usr/lib/polkit-gnome/polkit-gnome-authentication-agent-1 nm-applet xfce4-power-manager blueman-applet swaync swayidle swaylock waybar; Waybar commands [ERROR]: gsimplecal pulsemixer nm-connection-editor alacritty htop ncdu xfce4-power-manager; [WARN] pacman not found; [WARN] No Hyprland log found)*

------
https://chatgpt.com/codex/tasks/task_e_688f25aa781c83309d63c30e92c99267