### PR TITLE
Fix update script and hyprland config

### DIFF
--- a/.config/hypr/hyprland.conf
+++ b/.config/hypr/hyprland.conf
@@ -31,7 +31,7 @@ decoration {
 
 general {
     gaps_in = 2
-    gaps_out = 5 0 0 0
+    gaps_out = 5
     border_size = 2
     col.active_border = rgba(0,255,0,1)
     col.inactive_border = rgba(0,255,0,0.5)
@@ -138,3 +138,4 @@ bind = $mainMod CTRL SHIFT, RIGHT, resizeactive, 50 0
 bind = $mainMod CTRL SHIFT, UP, resizeactive, 0 -50
 bind = $mainMod CTRL SHIFT, DOWN, resizeactive, 0 50
 bind = CTRL ALT, DELETE, exit
+

--- a/update.sh
+++ b/update.sh
@@ -161,6 +161,7 @@ for dir in "${DIRS[@]}"; do
     echo -e "\nSyncing $dir configuration..."
     rm -rf "$CONFIG_DEST/$dir"
     cp -r ".config/$dir" "$CONFIG_DEST/"
+    chown -R "$TARGET_USER":"$TARGET_USER" "$CONFIG_DEST/$dir" || true
     step=$((step+1))
     progress $step $total
 done
@@ -168,6 +169,11 @@ done
 # Validate configuration
 if [[ -x "$SCRIPT_DIR/validate.sh" ]]; then
     sudo -u "$TARGET_USER" "$SCRIPT_DIR/validate.sh"
+fi
+
+if command -v hyprctl >/dev/null 2>&1; then
+    echo -e "\nReloading Hyprland configuration..."
+    sudo -u "$TARGET_USER" hyprctl reload || true
 fi
 
 echo -e "\nHyprRice update complete."


### PR DESCRIPTION
## Summary
- ensure update script copies configs with correct ownership and reloads Hyprland
- fix Hyprland config gaps_out directive and add final newline

## Testing
- `bash -n update.sh`
- `./validate.sh` *(fails: swaybg /usr/lib/polkit-gnome/polkit-gnome-authentication-agent-1 nm-applet xfce4-power-manager blueman-ap plet swaync swayidle swaylock waybar)*

------
https://chatgpt.com/codex/tasks/task_e_688f28ec6140833092970ec06dfb1ab6