### PR TITLE
Refine Hyprland config and harden scripts

### DIFF
--- a/.config/hypr/hyprland.conf
+++ b/.config/hypr/hyprland.conf
@@ -18,10 +18,12 @@ animations {
 
 decoration {
     rounding = 0
-    drop_shadow = false
-    shadow_range = 4
-    shadow_render_power = 3
-    col.shadow = rgba(0,0,0,0.25)
+    shadow {
+        enabled = false
+        range = 4
+        render_power = 3
+        color = rgba(0,0,0,0.25)
+    }
     active_opacity = 1.0
     inactive_opacity = 1.0
     blur {
@@ -69,7 +71,7 @@ bind = $mainMod, B, exec, firefox
 bind = $mainMod, L, exec, swaylock
 bind = $mainMod, M, exec, wlogout
 bind = $mainMod, Q, killactive
-bind = $mainMod, W, killactive force
+bind = $mainMod, W, killactive, force
 bind = $mainMod, F, fullscreen
 bind = $mainMod, V, togglefloating
 bind = $mainMod, J, layoutmsg, togglesplit

--- a/install.sh
+++ b/install.sh
@@ -157,7 +157,7 @@ done
 
 # Validate configuration
 if [[ -x "$SCRIPT_DIR/validate.sh" ]]; then
-    sudo -u "$TARGET_USER" "$SCRIPT_DIR/validate.sh"
+    sudo -u "$TARGET_USER" "$SCRIPT_DIR/validate.sh" || echo "Validation reported issues."
 fi
 
 echo -e '\nHyprRice installation complete.'

--- a/update.sh
+++ b/update.sh
@@ -178,7 +178,7 @@ done
 
 # Validate configuration
 if [[ -x "$SCRIPT_DIR/validate.sh" ]]; then
-    sudo -u "$TARGET_USER" "$SCRIPT_DIR/validate.sh"
+    sudo -u "$TARGET_USER" "$SCRIPT_DIR/validate.sh" || echo "Validation reported issues."
 fi
 
 if command -v hyprctl >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- Restructure Hyprland decoration settings and correct killactive binding
- Allow install/update scripts to continue when validation reports issues
- Improve system check with safer service detection and proper loops

## Testing
- `./validate.sh`
- `./system_check.sh`

------
https://chatgpt.com/codex/tasks/task_e_688f31970e00833088f14b71c9849863