### PR TITLE
Fix Hyprland bind and waybar hover styling

### DIFF
--- a/.config/hypr/hyprland.conf
+++ b/.config/hypr/hyprland.conf
@@ -125,7 +125,7 @@ bind = , XF86MonBrightnessDown, exec, brightnessctl set 10%-
 bind = , Print, exec, grim "$HOME/Pictures/Screenshots/$(date +'%Y-%m-%d-%H%M%S').png"
 bind = $mainMod, S, exec, grim -g "$(slurp)" - | swappy -f -
 bind = ALT, TAB, cyclenext
-bind = ALT SHIFT, TAB, cycleprev
+bind = ALT SHIFT, TAB, cyclenext, prev
 
 # Additional keybindings
 bind = $mainMod, Y, pin

--- a/.config/waybar/style.css
+++ b/.config/waybar/style.css
@@ -8,13 +8,36 @@ window#waybar {
   color: #00ff00;
 }
 
+window#waybar .module {
+  padding: 0 6px;
+  margin: 0 4px;
+  border-radius: 4px;
+  transition: background 0.3s ease, color 0.3s ease;
+}
+
+window#waybar .module:hover {
+  background: #003300;
+  color: #ffffff;
+}
+
 #workspaces button {
-  padding: 0 4px;
+  padding: 0 6px;
+  margin: 0 2px;
   background: transparent;
+  border-radius: 4px;
+  transition: background 0.3s ease;
 }
 
 #workspaces button.active {
   background: #005500;
+}
+
+#workspaces button:hover {
+  background: #003300;
+}
+
+#workspaces {
+  margin-left: 6px;
 }
 
 #pulseaudio.muted {

--- a/fix_login_theme.sh
+++ b/fix_login_theme.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Script to fix greetd login screen theme
+set -euo pipefail
+
+RED='\e[31m'; GREEN='\e[32m'; YELLOW='\e[33m'; RESET='\e[0m'
+
+if [[ $EUID -ne 0 ]]; then
+    echo -e "${RED}This script must be run as root.${RESET}"
+    exit 1
+fi
+
+PKGS=(greetd greetd-tuigreet)
+if command -v pacman >/dev/null 2>&1; then
+    missing=()
+    for pkg in "${PKGS[@]}"; do
+        pacman -Qi "$pkg" >/dev/null 2>&1 || missing+=("$pkg")
+    done
+    if ((${#missing[@]})); then
+        echo -e "Installing missing packages: ${missing[*]}"
+        pacman -S --needed --noconfirm "${missing[@]}" || true
+    fi
+else
+    echo -e "${YELLOW}pacman not found; skipping package installation.${RESET}"
+fi
+
+CFG_DIR=/etc/greetd
+CFG_FILE=$CFG_DIR/config.toml
+mkdir -p "$CFG_DIR"
+
+cat > "$CFG_FILE" <<'EOC'
+[terminal]
+vt = 1
+
+[default_session]
+command = "tuigreet --time --user-menu --cmd Hyprland --theme 'text=green;prompt=green;input=green;container=black;border=green;title=green;action=green;button=green'"
+user = "greeter"
+EOC
+
+if command -v systemctl >/dev/null 2>&1; then
+    systemctl enable --now greetd.service || true
+else
+    echo -e "${YELLOW}systemctl not found; cannot enable greetd.${RESET}"
+fi
+
+echo -e "${GREEN}Login screen theme applied. Reboot to see changes.${RESET}"

--- a/validate.sh
+++ b/validate.sh
@@ -49,6 +49,19 @@ else
     fi
 fi
 
+echo -e "${BLUE}Running Hyprland --validate...${RESET}"
+if command -v hyprland >/dev/null 2>&1; then
+    if hyprland --config "$HYPR_CONF" --validate >/tmp/hypr_validate 2>&1; then
+        echo -e "Hyprland validation ${GREEN}[OK]${RESET}"
+    else
+        echo -e "Hyprland validation ${RED}[ERROR]${RESET}:"
+        cat /tmp/hypr_validate
+        errors=$((errors+1))
+    fi
+else
+    echo -e "${YELLOW}[WARN]${RESET} hyprland not found; skipping full config validation"
+fi
+
 echo -e "${BLUE}Checking Hyprland exec commands...${RESET}"
 if [[ -f "$HYPR_CONF" ]]; then
     declare -A seen


### PR DESCRIPTION
## Summary
- fix invalid Hyprland `cycleprev` dispatcher
- add hover styles and spacing for Waybar modules
- validate Hyprland config and add greetd theme fixer script

## Testing
- `./validate.sh` (fails: Exec commands [ERROR]: swaybg /usr/lib/polkit-gnome/polkit-gnome-authentication-agent-1 nm-applet xfce4-power-manager blueman-applet swaync swayidle swaylock waybar; Waybar commands [ERROR]: gsimplecal pulsemixer nm-connection-editor alacritty htop ncdu xfce4-power-manager)
- `sudo ./fix_login_theme.sh` (fails: Failed to enable unit, unit greetd.service does not exist.)

------
https://chatgpt.com/codex/tasks/task_e_688f35ee5c248330802cb88b9a108a2e