### PR TITLE
Improve Waybar modules and workspace switching

### DIFF
--- a/.config/hypr/hyprland.conf
+++ b/.config/hypr/hyprland.conf
@@ -75,8 +75,11 @@ bind = $mainMod, W, killactive, force
 bind = $mainMod, F, fullscreen
 bind = $mainMod, V, togglefloating
 bind = $mainMod, J, layoutmsg, togglesplit
-bind = $mainMod, TAB, workspace, previous
 bind = $mainMod, C, exec, ~/.config/hypr/scripts/center-float-zoom.sh
+
+# Switch to next/previous workspace with Super+Tab
+bind = $mainMod, TAB, exec, hyprctl dispatch workspace +1
+bind = $mainMod SHIFT, TAB, exec, hyprctl dispatch workspace -1
 
 # Move focus
 bind = $mainMod, LEFT, movefocus, l

--- a/.config/waybar/config
+++ b/.config/waybar/config
@@ -7,11 +7,10 @@
     "spacing": 10
   },
   "modules-left": [
-    "workspaces"
-  ],
-  "modules-center": [
+    "workspaces",
     "clock"
   ],
+  "modules-center": [],
   "modules-right": [
     "pulseaudio",
     "network",
@@ -24,32 +23,39 @@
   "clock": {
     "format": "{:%Y-%m-%d %H:%M}",
     "tooltip": true,
-    "tooltip-format": "{:%A, %B %d %Y}",
-    "on-click": "gsimplecal"
+    "tooltip-format": "<tt><small>{calendar}</small></tt>",
+    "on-click": "alacritty -e cal",
+    "calendar": {
+      "mode": "month",
+      "weeks-pos": "right",
+      "format": {
+        "today": "<b><u>{}</u></b>"
+      }
+    }
   },
   "pulseaudio": {
-    "format": " VOL {volume}%",
-    "format-muted": " VOL {volume}%",
+    "format": "   VOL {volume}%",
+    "format-muted": "   VOL {volume}%",
     "tooltip": true,
     "tooltip-format": "Volume: {volume}%",
     "on-click": "alacritty -e pulsemixer"
   },
   "network": {
-    "format-wifi": " NET {signalStrength}%",
-    "format-ethernet": " NET {ipaddr}",
-    "format-disconnected": " NET down",
+    "format-wifi": "   NET {signalStrength}%",
+    "format-ethernet": "   NET {ipaddr}",
+    "format-disconnected": "   NET down",
     "tooltip": true,
     "tooltip-format": "SSID: {essid}\nSignal: {signalStrength}%\nIP: {ipaddr}",
     "on-click": "nm-connection-editor"
   },
   "cpu": {
-    "format": " CPU {usage}%",
+    "format": "   CPU {usage}%",
     "tooltip": true,
     "tooltip-format": "CPU usage: {usage}%",
     "on-click": "alacritty -e htop"
   },
   "memory": {
-    "format": " MEM {used}G/{total}G",
+    "format": "󰍛   MEM {used}G/{total}G",
     "tooltip": true,
     "tooltip-format": "Memory used: {used}G / {total}G",
     "on-click": "alacritty -e htop"
@@ -62,9 +68,9 @@
     "on-click": "alacritty -e ncdu /"
   },
   "battery": {
-    "format": " BAT {capacity}%",
-    "format-charging": " BAT {capacity}%",
-    "format-full": " BAT full",
+    "format": "   BAT {capacity}%",
+    "format-charging": "   BAT {capacity}%",
+    "format-full": "   BAT full",
     "tooltip": true,
     "tooltip-format": "Battery: {capacity}%",
     "on-click": "xfce4-power-manager-settings"

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The install and update scripts ensure the following packages are present:
 - firefox
 - grim
 - gvfs
-- gsimplecal
+- util-linux
 - greetd
 - greetd-tuigreet
 - htop
@@ -94,9 +94,15 @@ HyprRice is a matrix-inspired configuration for the [Hyprland](https://github.co
 - Animations disabled for snappy performance
 - Small inner gaps for tiling and a minimal top gap for Waybar
 - Waybar for system status and Wofi as application launcher
-- Waybar modules show tooltips and launch pulsemixer, NetworkManager, calendar, and power settings when clicked
+- Waybar modules show tooltips and launch pulsemixer, NetworkManager, terminal calendar, and power settings when clicked
 - Autostarts Waybar along with a polkit agent, NetworkManager, Bluetooth, power and notification applets
 - Solid black wallpaper via swaybg
+
+## Features / Updates
+
+- Workspace indicator and clock sit on the left; hovering the clock shows a monthly calendar with the current date underlined.
+- Cycle through workspaces with <kbd>Super</kbd>+<kbd>Tab</kbd> and <kbd>Super</kbd>+<kbd>Shift</kbd>+<kbd>Tab</kbd>; the Waybar workspace module reflects the active desktop.
+- System status icons (CPU, memory, network, volume, battery) now use consistent spacing and a working memory glyph.
 
 ## Keybindings
 
@@ -118,7 +124,8 @@ HyprRice is a matrix-inspired configuration for the [Hyprland](https://github.co
 | **Super + Ctrl + Arrow Keys** | Send window to adjacent workspace |
 | **Super + [1-9]** | Switch to workspace 1-9 |
 | **Super + Shift + [1-9]** | Move window to workspace 1-9 |
-| **Super + Tab** | Switch to previous workspace |
+| **Super + Tab** | Switch to next workspace |
+| **Super + Shift + Tab** | Switch to previous workspace |
 | **Alt + Tab** | Cycle through windows |
 | **Print** | Screenshot full screen |
 | **Super + S** | Screenshot region |
@@ -131,7 +138,7 @@ The install script installs all required packages including a polkit agent, noti
 
 | Module | Click Action |
 |--------|--------------|
-| Clock | Open `gsimplecal` calendar |
+| Clock | Open `cal` in Alacritty |
 | Audio | Launch `pulsemixer` |
 | Network | Launch `nm-connection-editor` |
 | Battery | Open `xfce4-power-manager-settings` (provided by `xfce4-power-manager`) |

--- a/install.sh
+++ b/install.sh
@@ -35,7 +35,6 @@ packages=(
     firefox
     grim
     gvfs
-    gsimplecal
     greetd
     greetd-tuigreet
     htop
@@ -63,6 +62,7 @@ packages=(
     thunar
     ttf-font-awesome
     ttf-jetbrains-mono-nerd
+    util-linux
     waybar
     wlogout
     wofi

--- a/update.sh
+++ b/update.sh
@@ -36,7 +36,6 @@ packages=(
     firefox
     grim
     gvfs
-    gsimplecal
     greetd
     greetd-tuigreet
     htop
@@ -64,6 +63,7 @@ packages=(
     thunar
     ttf-font-awesome
     ttf-jetbrains-mono-nerd
+    util-linux
     waybar
     wlogout
     wofi

--- a/validate.sh
+++ b/validate.sh
@@ -105,7 +105,7 @@ fi
 # Commands that Waybar modules rely on. The power manager settings binary is
 # provided by the xfce4-power-manager package, so we check for the package's
 # main command here.
-WAYBAR_CMDS=(gsimplecal pulsemixer nm-connection-editor alacritty htop ncdu xfce4-power-manager)
+WAYBAR_CMDS=(cal pulsemixer nm-connection-editor alacritty htop ncdu xfce4-power-manager)
 missing_waybar=()
 for cmd in "${WAYBAR_CMDS[@]}"; do
     command -v "$cmd" >/dev/null 2>&1 || missing_waybar+=("$cmd")
@@ -119,8 +119,8 @@ fi
 
 echo -e "${BLUE}Checking required packages...${RESET}"
 packages=(
-    alacritty archlinux-xdg-menu bluez bluez-utils blueman brightnessctl desktop-file-utils firefox grim gvfs gsimplecal greetd
-greetd-tuigreet htop hyprland jq ncdu networkmanager network-manager-applet nm-connection-editor nwg-look pipewire pipewire-pulse pipewire-alsa wireplumber alsa-utils pulsemixer polkit-gnome power-profiles-daemon slurp swappy swaybg swayidle swaylock swaync thunar ttf-font-awesome ttf-jetbrains-mono-nerd waybar wlogout wofi xdg-desktop-portal xdg-desktop-portal-hyprland xfce4-power-manager xfce4-settings xorg-xwayland
+    alacritty archlinux-xdg-menu bluez bluez-utils blueman brightnessctl desktop-file-utils firefox grim gvfs greetd
+greetd-tuigreet htop hyprland jq ncdu networkmanager network-manager-applet nm-connection-editor nwg-look pipewire pipewire-pulse pipewire-alsa wireplumber alsa-utils pulsemixer polkit-gnome power-profiles-daemon slurp swappy swaybg swayidle swaylock swaync thunar ttf-font-awesome ttf-jetbrains-mono-nerd util-linux waybar wlogout wofi xdg-desktop-portal xdg-desktop-portal-hyprland xfce4-power-manager xfce4-settings xorg-xwayland
 )
 if command -v pacman >/dev/null 2>&1; then
     missing_pkgs=()


### PR DESCRIPTION
## Summary
- Fix Waybar memory icon and add uniform spacing for status modules.
- Move clock next to workspaces with a hover calendar tooltip and `cal` on click; remove gsimplecal dependency.
- Add Super+Tab shortcuts for cycling workspaces and document the new behaviour.

## Testing
- `./validate.sh` *(fails: missing executables: swaybg, polkit-gnome, nm-applet, xfce4-power-manager, blueman-applet, swaync, swayidle, swaylock, waybar, cal, pulsemixer, nm-connection-editor, alacritty, htop, ncdu, xfce4-power-manager)*


------
https://chatgpt.com/codex/tasks/task_e_688f831f22808330826dcc4debcff9d2