### PR TITLE
feat: improve workspace indicator and calendar

### DIFF
--- a/.config/waybar/config
+++ b/.config/waybar/config
@@ -7,7 +7,7 @@
     "spacing": 10
   },
   "modules-left": [
-    "workspaces",
+    "hyprland/workspaces",
     "clock"
   ],
   "modules-center": [],
@@ -23,7 +23,7 @@
   "clock": {
     "format": "{:%Y-%m-%d %H:%M}",
     "tooltip": true,
-    "tooltip-format": "<tt><small>{calendar}</small></tt>",
+    "tooltip-format": "<tt><big>{calendar}</big></tt>",
     "on-click": "alacritty -e cal",
     "calendar": {
       "mode": "month",
@@ -75,9 +75,9 @@
     "tooltip-format": "Battery: {capacity}%",
     "on-click": "xfce4-power-manager-settings"
   },
-  "workspaces": {
+  "hyprland/workspaces": {
     "format": "{id}",
-    "sort-by-number": true,
+    "active-only": true,
     "on-scroll-up": "hyprctl dispatch workspace -1",
     "on-scroll-down": "hyprctl dispatch workspace +1",
     "on-click": "hyprctl dispatch workspace {id}",

--- a/.config/waybar/style.css
+++ b/.config/waybar/style.css
@@ -20,7 +20,7 @@ window#waybar .module:hover {
   color: #ffffff;
 }
 
-#workspaces button {
+#hyprland-workspaces button {
   padding: 0 6px;
   margin: 0 2px;
   background: transparent;
@@ -28,15 +28,15 @@ window#waybar .module:hover {
   transition: background 0.3s ease;
 }
 
-#workspaces button.active {
+#hyprland-workspaces button.active {
   background: #005500;
 }
 
-#workspaces button:hover {
+#hyprland-workspaces button:hover {
   background: #003300;
 }
 
-#workspaces {
+#hyprland-workspaces {
   margin-left: 6px;
 }
 


### PR DESCRIPTION
## Summary
- show active workspace in Waybar using hyprland module
- enlarge calendar tooltip for easier reading
- update Waybar CSS to match new workspace module

## Testing
- `./validate.sh` *(fails: hyprland not found; missing commands: swaybg /usr/lib/polkit-gnome/polkit-gnome-authentication-agent-1 nm-applet xfce4-power-manager blueman-applet swaync swayidle swaylock waybar; cal pulsemixer nm-connection-editor alacritty htop ncdu xfce4-power-manager)*

------
https://chatgpt.com/codex/tasks/task_e_688f9caf01888330a037063f711a1ef5