### PR TITLE
Add Python and media dependencies with TV app setup

### DIFF
--- a/PC_Setup.sh
+++ b/PC_Setup.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# PC_Setup.sh: Unified setup script for HyprRice and optional components
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+echo "Running HyprRice install script..."
+bash "$SCRIPT_DIR/install.sh"
+
+echo "Applying login screen theme..."
+bash "$SCRIPT_DIR/fix_login_theme.sh"
+
+echo "Applying sound fix..."
+bash "$SCRIPT_DIR/fix_sound.sh"
+
+echo "Updating configuration..."
+bash "$SCRIPT_DIR/update.sh"
+
+echo "Running system check..."
+bash "$SCRIPT_DIR/system_check.sh"
+
+echo "Installing TV application..."
+bash "$SCRIPT_DIR/install_tv.sh"
+
+if [[ ":$PATH:" != *":$HOME/.local/bin:"* ]]; then
+    echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$HOME/.bashrc"
+    echo "Added ~/.local/bin to PATH in ~/.bashrc"
+fi
+
+echo "Setup complete! You can now reboot and log in to Hyprland. Enjoy."
+

--- a/README.md
+++ b/README.md
@@ -9,7 +9,13 @@
    cd HyprRice
    ./install.sh
    ```
-   Replace `YOUR_GITHUB_USERNAME` with your GitHub account name. The script installs required packages, configures the `greetd` login manager and copies the configuration into `~/.config` for the current user.
+    Replace `YOUR_GITHUB_USERNAME` with your GitHub account name. The script installs required packages, configures the `greetd` login manager and copies the configuration into `~/.config` for the current user.
+
+For a complete setup including fixes and the optional TV application, run:
+
+```bash
+./PC_Setup.sh
+```
 
 ### Packages installed
 
@@ -59,6 +65,16 @@ The install and update scripts ensure the following packages are present:
 - xdg-desktop-portal-hyprland
 - xfce4-power-manager
 - xfce4-settings
+- ffmpeg
+- gstreamer
+- gst-plugins-good
+- gst-libav
+- python
+- python-pip
+- python-pyqt5
+- qt5-multimedia
+- qt5-wayland
+- yt-dlp
 
 On reboot you'll see a neon green `greetd` prompt. After authenticating, Hyprland starts automatically.
 
@@ -82,6 +98,13 @@ Run the diagnostic script to verify graphics, audio and core services are ready:
 
 The script reports missing commands or inactive services so you can install the
 appropriate packages or start the required daemons.
+
+## TV Streaming Application Integration
+
+`PC_Setup.sh` can install a Python/Qt-based TV streaming application from the
+[`codexTest`](https://github.com/TheZedxD/codexTest) repository. After running
+the setup script, launch the app from your application menu or by running
+`python3 ~/codexTest/app.py`.
 
 ## About
 

--- a/install.sh
+++ b/install.sh
@@ -63,6 +63,16 @@ packages=(
     ttf-font-awesome
     ttf-jetbrains-mono-nerd
     util-linux
+    ffmpeg
+    gstreamer
+    gst-plugins-good
+    gst-libav
+    python
+    python-pip
+    python-pyqt5
+    qt5-multimedia
+    qt5-wayland
+    yt-dlp
     waybar
     wlogout
     wofi

--- a/install_tv.sh
+++ b/install_tv.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# install_tv.sh: Clone and set up the optional TV application
+set -euo pipefail
+
+TV_REPO="https://github.com/TheZedxD/codexTest.git"
+TV_DIR="$HOME/codexTest"
+
+if [ -d "$TV_DIR/.git" ]; then
+    echo "TV app directory already exists. Pulling latest changes..."
+    git -C "$TV_DIR" pull --ff-only || true
+else
+    echo "Cloning TV app repository to $TV_DIR..."
+    git clone "$TV_REPO" "$TV_DIR"
+fi
+
+if [ -f "$TV_DIR/requirements.txt" ]; then
+    echo "Installing Python dependencies for TV app..."
+    python3 -m pip install --upgrade pip
+    python3 -m pip install -r "$TV_DIR/requirements.txt"
+fi
+
+MAIN_SCRIPT=""
+for candidate in app.py main.py; do
+    if [ -f "$TV_DIR/$candidate" ]; then
+        MAIN_SCRIPT="$TV_DIR/$candidate"
+        break
+    fi
+done
+[ -z "$MAIN_SCRIPT" ] && MAIN_SCRIPT="$TV_DIR/app.py"
+
+APPDESK="$HOME/.local/share/applications/TVApp.desktop"
+mkdir -p "$(dirname "$APPDESK")"
+cat >"$APPDESK" <<EOF
+[Desktop Entry]
+Type=Application
+Name=TV Media App
+Comment=Launch the TV streaming application
+Exec=python3 $MAIN_SCRIPT
+Icon=video-display
+Terminal=false
+Categories=AudioVideo;
+EOF
+
+echo "TV application installed. Launch it from your application menu or by running 'python3 $MAIN_SCRIPT'."
+

--- a/update.sh
+++ b/update.sh
@@ -64,6 +64,16 @@ packages=(
     ttf-font-awesome
     ttf-jetbrains-mono-nerd
     util-linux
+    ffmpeg
+    gstreamer
+    gst-plugins-good
+    gst-libav
+    python
+    python-pip
+    python-pyqt5
+    qt5-multimedia
+    qt5-wayland
+    yt-dlp
     waybar
     wlogout
     wofi

--- a/validate.sh
+++ b/validate.sh
@@ -119,8 +119,7 @@ fi
 
 echo -e "${BLUE}Checking required packages...${RESET}"
 packages=(
-    alacritty archlinux-xdg-menu bluez bluez-utils blueman brightnessctl desktop-file-utils firefox grim gvfs greetd
-greetd-tuigreet htop hyprland jq ncdu networkmanager network-manager-applet nm-connection-editor nwg-look pipewire pipewire-pulse pipewire-alsa wireplumber alsa-utils pulsemixer polkit-gnome power-profiles-daemon slurp swappy swaybg swayidle swaylock swaync thunar ttf-font-awesome ttf-jetbrains-mono-nerd util-linux waybar wlogout wofi xdg-desktop-portal xdg-desktop-portal-hyprland xfce4-power-manager xfce4-settings xorg-xwayland
+    alacritty archlinux-xdg-menu bluez bluez-utils blueman brightnessctl desktop-file-utils firefox ffmpeg grim gvfs greetd greetd-tuigreet gstreamer gst-plugins-good gst-libav htop hyprland jq ncdu networkmanager network-manager-applet nm-connection-editor nwg-look pipewire pipewire-pulse pipewire-alsa wireplumber alsa-utils pulsemixer polkit-gnome power-profiles-daemon python python-pip python-pyqt5 qt5-multimedia qt5-wayland slurp swappy swaybg swayidle swaylock swaync thunar ttf-font-awesome ttf-jetbrains-mono-nerd util-linux waybar wlogout wofi xdg-desktop-portal xdg-desktop-portal-hyprland xfce4-power-manager xfce4-settings xorg-xwayland yt-dlp
 )
 if command -v pacman >/dev/null 2>&1; then
     missing_pkgs=()


### PR DESCRIPTION
## Summary
- install Python, Qt, ffmpeg, GStreamer and yt-dlp for the upcoming TV app
- add `PC_Setup.sh` to automate install, fixes, checks and TV app setup
- provide `install_tv.sh` to clone and configure the codexTest TV application

## Testing
- `./validate.sh` *(fails: Exec commands [ERROR]: swaybg /usr/lib/polkit-gnome/polkit-gnome-authentication-agent-1 nm-applet xfce4-power-manager blueman-applet swaync swayidle swaylock waybar, Waybar commands [ERROR]: cal pulsemixer nm-connection-editor alacritty htop ncdu xfce4-power-manager)*

------
https://chatgpt.com/codex/tasks/task_e_68902921c5c88330b9f798976113b832