### PR TITLE
feat: add Waybar power button module

### DIFF
--- a/.config/waybar/config
+++ b/.config/waybar/config
@@ -8,6 +8,7 @@
   },
   "modules-left": [
     "hyprland/workspaces",
+    "custom/power",
     "clock"
   ],
   "modules-center": [],
@@ -32,6 +33,12 @@
         "today": "<b><u>{}</u></b>"
       }
     }
+  },
+  "custom/power": {
+    "format": "",
+    "tooltip": true,
+    "tooltip-format": "Power menu",
+    "on-click": "wlogout"
   },
   "pulseaudio": {
     "format": "   VOL {volume}%",

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ HyprRice is a matrix-inspired configuration for the [Hyprland](https://github.co
 - Animations disabled for snappy performance
 - Small inner gaps for tiling and a minimal top gap for Waybar
 - Waybar for system status and Wofi as application launcher
-- Waybar modules show tooltips and launch pulsemixer, NetworkManager, terminal calendar, and power settings when clicked
+- Waybar modules show tooltips and launch pulsemixer, NetworkManager, terminal calendar, wlogout power menu, and power settings when clicked
 - Autostarts Waybar along with a polkit agent, NetworkManager, Bluetooth, power and notification applets
 - Solid black wallpaper via swaybg
 
@@ -173,6 +173,7 @@ The install script installs all required packages including a polkit agent, noti
 
 | Module | Click Action |
 |--------|--------------|
+| Power | Open `wlogout` power menu |
 | Clock | Open `cal` in Alacritty |
 | Audio | Launch `pulsemixer` |
 | Network | Launch `nm-connection-editor` |

--- a/validate.sh
+++ b/validate.sh
@@ -105,7 +105,7 @@ fi
 # Commands that Waybar modules rely on. The power manager settings binary is
 # provided by the xfce4-power-manager package, so we check for the package's
 # main command here.
-WAYBAR_CMDS=(cal pulsemixer nm-connection-editor alacritty htop ncdu xfce4-power-manager)
+WAYBAR_CMDS=(wlogout cal pulsemixer nm-connection-editor alacritty htop ncdu xfce4-power-manager)
 missing_waybar=()
 for cmd in "${WAYBAR_CMDS[@]}"; do
     command -v "$cmd" >/dev/null 2>&1 || missing_waybar+=("$cmd")


### PR DESCRIPTION
## Summary
- add Waybar power module launching wlogout
- document power menu in README
- validate wlogout binary in validation script

## Testing
- `./validate.sh` *(fails: missing swaybg, wlogout, cal, pulsemixer, nm-connection-editor, alacritty, htop, ncdu, xfce4-power-manager)*

------
https://chatgpt.com/codex/tasks/task_e_689044c090148330b831b06f79b99319