### PR TITLE
Ensure greetd login replaces other display managers

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
    cd HyprRice
    ./install.sh
    ```
-    Replace `YOUR_GITHUB_USERNAME` with your GitHub account name. The script installs required packages, configures the `greetd` login manager and copies the configuration into `~/.config` for the current user.
+    Replace `YOUR_GITHUB_USERNAME` with your GitHub account name. The script installs required packages, configures the `greetd` login manager and copies the configuration into `~/.config` for the current user. Existing display managers (gdm, sddm, lightdm, etc.) are disabled so `greetd` becomes active.
 
 For a complete setup including fixes and the optional TV application, run the
 umbrella script which logs progress to `setup.log`:
@@ -167,7 +167,7 @@ HyprRice is a matrix-inspired configuration for the [Hyprland](https://github.co
 
 ## Notes
 
-The install script installs all required packages including a polkit agent, notification daemon, NetworkManager, and the `greetd` login manager.
+The install script installs all required packages including a polkit agent, notification daemon, NetworkManager, and the `greetd` login manager while disabling other display managers.
 
 ## Waybar Actions
 

--- a/fix_login_theme.sh
+++ b/fix_login_theme.sh
@@ -37,9 +37,13 @@ user = "greeter"
 EOC
 
 if command -v systemctl >/dev/null 2>&1; then
+    DM_SERVICES=(gdm.service sddm.service lightdm.service lxdm.service ly.service)
+    for svc in "${DM_SERVICES[@]}"; do
+        systemctl disable --now "$svc" >/dev/null 2>&1 || true
+    done
     systemctl enable --now greetd.service || true
 else
-    echo -e "${YELLOW}systemctl not found; cannot enable greetd.${RESET}"
+    echo -e "${YELLOW}systemctl not found; cannot manage display managers.${RESET}"
 fi
 
 echo -e "${GREEN}Login screen theme applied. Reboot to see changes.${RESET}"

--- a/install.sh
+++ b/install.sh
@@ -134,7 +134,11 @@ if command -v systemctl >/dev/null 2>&1; then
     sudo systemctl enable --now bluetooth.service || true
     sudo systemctl enable --now power-profiles-daemon.service || true
     sudo -u "$TARGET_USER" systemctl --user restart xdg-desktop-portal-hyprland.service || true
-    sudo systemctl enable greetd.service || true
+    DM_SERVICES=(gdm.service sddm.service lightdm.service lxdm.service ly.service)
+    for svc in "${DM_SERVICES[@]}"; do
+        sudo systemctl disable --now "$svc" >/dev/null 2>&1 || true
+    done
+    sudo systemctl enable --now greetd.service || true
 fi
 
 if command -v sudo >/dev/null 2>&1; then

--- a/update.sh
+++ b/update.sh
@@ -135,6 +135,10 @@ if command -v systemctl >/dev/null 2>&1; then
     sudo systemctl enable --now bluetooth.service || true
     sudo systemctl enable --now power-profiles-daemon.service || true
     sudo -u "$TARGET_USER" systemctl --user restart xdg-desktop-portal-hyprland.service || true
+    DM_SERVICES=(gdm.service sddm.service lightdm.service lxdm.service ly.service)
+    for svc in "${DM_SERVICES[@]}"; do
+        sudo systemctl disable --now "$svc" >/dev/null 2>&1 || true
+    done
     sudo systemctl enable greetd.service || true
 fi
 


### PR DESCRIPTION
## Summary
- Disable common display manager services before enabling greetd
- Update install and update scripts to ensure greetd becomes active
- Document that installation disables other login managers

## Testing
- `./validate.sh` *(fails: Exec commands [ERROR]: swaybg /usr/lib/polkit-gnome/polkit-gnome-authentication-agent-1 nm-applet xfce4-power-manager blueman-applet swaync swayidle swaylock waybar; Waybar commands [ERROR]: wlogout cal pulsemixer nm-connection-editor alacritty htop ncdu xfce4-power-manager; [WARN] pacman not found; [WARN] No Hyprland log found at /root/.cache/hyprland/hyprland.log)*

------
https://chatgpt.com/codex/tasks/task_e_689047ad1c2083308447abba0a27f6c0