### PR TITLE
feat: enhance workspace cycling and window controls

### DIFF
--- a/.config/hypr/hyprland.conf
+++ b/.config/hypr/hyprland.conf
@@ -13,7 +13,7 @@ animations {
     animation = fade, 1, 7, default
     animation = border, 1, 7, default
     animation = borderangle, 1, 7, default
-    animation = workspaces, 1, 7, default, slide
+    animation = workspaces, 0.3, 7, default, slide
 }
 
 decoration {
@@ -73,13 +73,12 @@ bind = $mainMod, M, exec, wlogout
 bind = $mainMod, Q, killactive
 bind = $mainMod, W, killactive, force
 bind = $mainMod, F, fullscreen
-bind = $mainMod, V, togglefloating
+bind = $mainMod, V, exec, ~/.config/hypr/scripts/center-float-zoom.sh
 bind = $mainMod, J, layoutmsg, togglesplit
-bind = $mainMod, C, exec, ~/.config/hypr/scripts/center-float-zoom.sh
 
 # Switch to next/previous workspace with Super+Tab
-bind = $mainMod, TAB, exec, hyprctl dispatch workspace +1
-bind = $mainMod SHIFT, TAB, exec, hyprctl dispatch workspace -1
+bind = $mainMod, TAB, workspace, m+1
+bind = $mainMod SHIFT, TAB, workspace, m-1
 
 # Move focus
 bind = $mainMod, LEFT, movefocus, l
@@ -96,8 +95,8 @@ bind = $mainMod SHIFT, DOWN, movewindow, d
 # Workspace navigation
 bind = $mainMod CTRL, LEFT, movetoworkspace, -1
 bind = $mainMod CTRL, RIGHT, movetoworkspace, +1
-bind = $mainMod, mouse_up, workspace, -1
-bind = $mainMod, mouse_down, workspace, +1
+bind = $mainMod, mouse_up, workspace, m-1
+bind = $mainMod, mouse_down, workspace, m+1
 
 # Switch workspace 1-9
 bind = $mainMod, 1, workspace, 1
@@ -133,8 +132,8 @@ bind = ALT SHIFT, TAB, cyclenext, prev
 # Additional keybindings
 bind = $mainMod, Y, pin
 bind = $mainMod, K, togglegroup
-bind = $mainMod, PERIOD, workspace, +1
-bind = $mainMod, COMMA, workspace, -1
+bind = $mainMod, PERIOD, workspace, m+1
+bind = $mainMod, COMMA, workspace, m-1
 bind = $mainMod, O, exec, pkill -SIGUSR2 waybar
 bind = $mainMod, G, exec, hyprctl keyword general:gaps_in 0 && hyprctl keyword general:gaps_out "0 0 0 0"
 bind = $mainMod SHIFT, G, exec, hyprctl keyword general:gaps_in 2 && hyprctl keyword general:gaps_out "5 0 0 0"
@@ -143,4 +142,12 @@ bind = $mainMod CTRL SHIFT, RIGHT, resizeactive, 50 0
 bind = $mainMod CTRL SHIFT, UP, resizeactive, 0 -50
 bind = $mainMod CTRL SHIFT, DOWN, resizeactive, 0 50
 bind = CTRL ALT, DELETE, exit
+
+# Alt + Left Mouse Button: drag to move windows, click to toggle float
+bindm = ALT, mouse:272, movewindow
+bindc = ALT, mouse:272, togglefloating
+
+# Float and center "Open With" dialogs
+windowrule = float, title:^(Open With)$
+windowrule = center, title:^(Open With)$
 

--- a/.config/waybar/config
+++ b/.config/waybar/config
@@ -7,8 +7,8 @@
     "spacing": 10
   },
   "modules-left": [
-    "hyprland/workspaces",
     "custom/power",
+    "hyprland/workspaces",
     "clock"
   ],
   "modules-center": [],


### PR DESCRIPTION
## Summary
- move Waybar power button to far left and keep dynamic workspaces beside it
- cycle only existing workspaces and speed up workspace switch animation
- add Alt-drag window move, Super+V zoom toggle, and float 'Open With' dialogs

## Testing
- `./validate.sh` *(fails: swaybg /usr/lib/polkit-gnome/polkit-gnome-authentication-agent-1 nm-applet xfce4-power-manager blueman-applet swaync swayidle swaylock waybar; Waybar commands missing: wlogout cal pulsemixer nm-connection-editor alacritty htop ncdu xfce4-power-manager)*

------
https://chatgpt.com/codex/tasks/task_e_6890877197008330ac748f4787ab43c9