### PR TITLE
Add enhancement guide documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ the setup script, launch the app from your application menu or by running
 
 HyprRice is a matrix-inspired configuration for the [Hyprland](https://github.com/hyprwm/Hyprland) Wayland compositor. It aims for a clean and minimal look with sharp edges and bright green accents.
 
+For forward-looking improvements and advanced setup techniques, see the [Enhancement Guide](docs/ENHANCEMENT_GUIDE.md).
+
 ## Features
 
 - Neon green "Matrix" theme with solid active/inactive borders

--- a/docs/ENHANCEMENT_GUIDE.md
+++ b/docs/ENHANCEMENT_GUIDE.md
@@ -1,0 +1,82 @@
+# HyprRice Enhancement Guide: Advanced Linux Setup Scripts for 2025
+
+Modern Linux desktop environment setup scripts have evolved far beyond simple package installation and configuration copying. Today's professional-grade dotfiles repositories integrate sophisticated error handling, automated maintenance, security hardening, and user experience features that rival commercial installers. This comprehensive research reveals cutting-edge techniques and tools that can transform HyprRice into a robust, maintainable, and user-friendly setup system.
+
+The landscape has shifted dramatically toward Wayland-native tooling, with Hyprland leading compositor innovation through HDR support, performance optimizations, and enhanced gaming features. Simultaneously, security concerns have elevated automated hardening and maintenance to essential requirements rather than optional additions.
+
+## Script architecture and reliability improvements
+
+**Error handling has evolved beyond basic `set -euo pipefail`** to include sophisticated trap-based recovery systems and stack-based rollback mechanisms. Modern scripts implement structured logging with multiple output streams, separating user-facing messages from debug information while maintaining comprehensive audit trails.
+
+```bash
+# Modern error handling pattern
+handle_error() {
+    local exit_code=$?
+    local line_number=$1
+    local command="$2"
+    echo "ERROR: Command failed with exit code $exit_code at line $line_number: $command" >&2
+    execute_rollback
+    exit $exit_code
+}
+
+trap 'handle_error $LINENO "$BASH_COMMAND"' ERR
+```
+
+**Configuration validation has become proactive rather than reactive**. Tools like `yamllint`, `jsonlint`, and `shellcheck` now integrate directly into setup scripts, preventing deployment of broken configurations. Pre-flight system checks validate disk space, memory, network connectivity, and required commands before any modifications occur.
+
+**Progress reporting utilizes modern terminal capabilities** with interactive progress bars, spinners for long-running operations, and structured user prompts with input validation. The shift from silent installation to transparent, guided setup significantly improves troubleshooting and user confidence.
+
+## Advanced installer capabilities and user experience
+
+**Automated backup systems have become sophisticated**, moving beyond simple file copying to BTRFS/LVM snapshots and incremental backup solutions using tools like BorgBackup. Modern installers create comprehensive system state snapshots before any changes, enabling atomic rollback capabilities integrated with bootloader recovery options.
+
+**Configuration migration tools address the complexity of evolving dotfiles**. Version detection algorithms identify existing configurations and apply appropriate migration scripts, ensuring seamless upgrades from older HyprRice versions. GNU Stow, Chezmoi, and YADM have emerged as the leading dotfiles management frameworks, each offering distinct advantages for different use cases.
+
+**Theme and color scheme management has advanced to dynamic switching systems**. Tools like `pywal` automatically generate cohesive color palettes, while modern theme managers coordinate GTK, Qt, icon themes, and desktop environment elements. Live preview capabilities allow users to test themes without system-wide application or restart requirements.
+
+**Hardware detection and optimization now drives automatic configuration selection**. Modern scripts detect GPU types, laptop vs desktop systems, display capabilities, and input devices to apply appropriate optimizations. Performance tuning automation uses the `tuned` daemon to select optimal system profiles based on hardware characteristics and intended use cases.
+
+## Hyprland ecosystem modernization
+
+**Hyprland 0.48.0+ introduces transformative features** including native HDR support with experimental color management, super-circular window corners for modern aesthetics, and significant performance improvements through memory safety enhancements and animation system rewrites. Gaming optimizations now include improved tearing support, direct scanout capabilities, and enhanced VRR handling.
+
+**The Wayland-native tool ecosystem has matured dramatically**. Screenshot functionality migrates from X11 tools to `grimblast` (official Hyprland utility), `hyprshot` with screen freeze capabilities, and `satty` for annotation. Traditional notification daemons give way to `mako` for lightweight operation, `SwayNotificationCenter` for feature-rich functionality, or `fnott` for keyboard-driven workflows.
+
+**Terminal emulator selection now prioritizes Wayland optimization**. `Foot` leads in performance with minimal resource usage and ultra-low latency, while `Alacritty` provides GPU acceleration and `WezTerm` offers advanced multiplexer capabilities with built-in SSH client functionality.
+
+**Application launchers have evolved beyond simple menu replacement**. `Fuzzel` provides excellent scaling support as a rofi alternative, `Tofi` offers minimal resource footprint for dmenu-like functionality, and `Anyrun` introduces plugin systems for extensible functionality.
+
+## Security hardening and maintenance automation
+
+**Modern security approaches implement comprehensive kernel hardening** using the `linux-hardened` package with paranoid security defaults. Boot parameters now include extensive mitigation strategies: `mitigations=auto,nosmt`, `spectre_v2=on`, `init_on_alloc=1`, and numerous other hardening options that address recent CPU vulnerabilities and attack vectors.
+
+**Permission management extends beyond traditional user access control** to include mandatory access control systems like AppArmor or SELinux, systematic SUID bit removal, and granular PolicyKit configurations for desktop services. File system security implements encryption at rest, restrictive mount options, and integrity monitoring through tools like AIDE.
+
+**Automated maintenance has replaced manual system administration tasks**. Systemd timers provide more robust scheduling than traditional cron jobs, while tools like `Netdata` offer zero-configuration real-time monitoring with web interfaces. Package management automation includes security-focused AUR handling with automated PKGBUILD review and checksum verification.
+
+**Secret management in dotfiles requires encrypted storage solutions**. `Git-crypt` encrypts sensitive files within repositories, `pass` provides Unix-style password management with GPG encryption, and modern tools like `age` offer file encryption for backup scenarios. Implementation patterns avoid hardcoded secrets through external injection mechanisms.
+
+## Modern tooling integration and replacement strategies
+
+**Status bar alternatives have expanded beyond Waybar** to include `Ironbar` (Rust-based with GTK4), `HyprPanel` (Hyprland-specific with context menus), `Yambar` (polybar-inspired modularity), and `EWW` (widget framework for custom interfaces). Each offers distinct advantages for different customization requirements and performance characteristics.
+
+**Session management now integrates GPU-accelerated solutions** like `Hyprlock` for screen locking, `Hypridle` for modern idle daemon functionality, and `Hyprpaper` for fast wallpaper management. These tools leverage Hyprland's architecture for optimal performance and integration.
+
+**Multi-monitor and display management utilizes sophisticated tools** like `Kanshi` for dynamic configuration, `nwg-displays` for GUI setup, and `Shikane` for deterministic output configuration. These solutions address complex multi-monitor scenarios with automatic adaptation to hardware changes.
+
+## Implementation strategies and practical considerations
+
+**Modular script architecture separates concerns into discrete, testable components**. Each module handles specific functionality (packages, themes, security, services) with clear interfaces and rollback capabilities. This approach enables selective installation, easier maintenance, and comprehensive testing through continuous integration systems.
+
+**User experience design incorporates professional installer patterns** including step-by-step wizards with progress indicators, validation at each stage, and summary confirmation before execution. Interactive prompts use robust validation patterns, while dry-run capabilities allow users to preview changes before application.
+
+**Security implementation requires careful balance between protection and usability**. Different security profiles (minimal, standard, paranoid) accommodate varying user requirements and threat models. Clear documentation explains potential compatibility impacts, while troubleshooting guides address common configuration conflicts.
+
+## Conclusion: toward professional-grade desktop automation
+
+The evolution from simple dotfiles copying to comprehensive system management represents a fundamental shift in Linux desktop setup automation. Modern HyprRice implementations should embrace these advanced techniques while maintaining the accessibility and customization that makes community-driven setups appealing.
+
+**Key implementation priorities include comprehensive error handling with rollback capabilities, security hardening with user choice, and integration of the latest Wayland-native tooling**. The combination of automated maintenance, sophisticated user experience design, and robust configuration management creates setup scripts that rival commercial solutions while preserving the flexibility and transparency that defines the Linux desktop experience.
+
+Success requires careful attention to user feedback, comprehensive testing across different hardware configurations, and commitment to maintaining current best practices as the ecosystem continues rapid evolution. The investment in these advanced techniques transforms setup scripts from simple automation into professional system management tools that enhance rather than complicate the user experience.
+


### PR DESCRIPTION
## Summary
- add comprehensive Enhancement Guide outlining modern setup, security, and tooling strategies
- reference the guide from README for easy discovery

## Testing
- `./validate.sh` *(fails: missing exec commands swaybg, polkit-gnome agent, nm-applet, xfce4-power-manager, blueman-applet, swaync, swayidle, swaylock, waybar; missing commands wlogout, cal, pulsemixer, nm-connection-editor, alacritty, htop, ncdu, xfce4-power-manager)*

------
https://chatgpt.com/codex/tasks/task_e_6890bf2a5d288330bae775a4ab37aa9e