### PR TITLE
feat: add robust error handling

### DIFF
--- a/fix_login_theme.sh
+++ b/fix_login_theme.sh
@@ -1,6 +1,16 @@
 #!/usr/bin/env bash
 # Script to fix greetd login screen theme
-set -euo pipefail
+set -Eeuo pipefail
+
+handle_error() {
+    local exit_code=$?
+    local line_number=$1
+    local command=$2
+    echo "ERROR: Command failed with exit code $exit_code at line $line_number: $command" >&2
+    exit $exit_code
+}
+
+trap 'handle_error $LINENO "$BASH_COMMAND"' ERR
 
 RED='\e[31m'; GREEN='\e[32m'; YELLOW='\e[33m'; RESET='\e[0m'
 

--- a/fix_sound.sh
+++ b/fix_sound.sh
@@ -1,7 +1,17 @@
 #!/usr/bin/env bash
 # fix_sound.sh — purge PulseAudio, enable PipeWire, unmute channels
 
-set -uo pipefail
+set -Eeuo pipefail
+
+handle_error() {
+    local exit_code=$?
+    local line_number=$1
+    local command=$2
+    echo "ERROR: Command failed with exit code $exit_code at line $line_number: $command" >&2
+    exit $exit_code
+}
+
+trap 'handle_error $LINENO "$BASH_COMMAND"' ERR
 RED='\e[31m'; GREEN='\e[32m'; YELLOW='\e[33m'; BOLD='\e[1m'; RESET='\e[0m'
 
 echo -e "${BOLD}${GREEN}▶ HyprRice Audio Repair${RESET}"

--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,17 @@
 # Simple installer for HyprRice dotfiles.
 # Copies configuration files into the current user's ~/.config directory.
 # If run with sudo, files will be placed in the invoking user's home.
-set -euo pipefail
+set -Eeuo pipefail
+
+handle_error() {
+    local exit_code=$?
+    local line_number=$1
+    local command=$2
+    echo "ERROR: Command failed with exit code $exit_code at line $line_number: $command" >&2
+    exit $exit_code
+}
+
+trap 'handle_error $LINENO "$BASH_COMMAND"' ERR
 
 TARGET_USER=${SUDO_USER:-$USER}
 TARGET_HOME=$(eval echo "~$TARGET_USER")

--- a/install_tv.sh
+++ b/install_tv.sh
@@ -1,6 +1,16 @@
 #!/usr/bin/env bash
 # install_tv.sh: Clone and set up the optional TV application
-set -euo pipefail
+set -Eeuo pipefail
+
+handle_error() {
+    local exit_code=$?
+    local line_number=$1
+    local command=$2
+    echo "ERROR: Command failed with exit code $exit_code at line $line_number: $command" >&2
+    exit $exit_code
+}
+
+trap 'handle_error $LINENO "$BASH_COMMAND"' ERR
 
 TV_REPO="https://github.com/TheZedxD/codexTest.git"
 TV_DIR="$HOME/codexTest"

--- a/setup.sh
+++ b/setup.sh
@@ -1,6 +1,16 @@
 #!/usr/bin/env bash
 # setup.sh: Orchestrate full HyprRice installation with logging
-set -euo pipefail
+set -Eeuo pipefail
+
+handle_error() {
+    local exit_code=$?
+    local line_number=$1
+    local command=$2
+    echo "ERROR: Command failed with exit code $exit_code at line $line_number: $command" >&2
+    exit $exit_code
+}
+
+trap 'handle_error $LINENO "$BASH_COMMAND"' ERR
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 LOG_FILE="$SCRIPT_DIR/setup.log"

--- a/system_check.sh
+++ b/system_check.sh
@@ -1,6 +1,16 @@
 #!/usr/bin/env bash
 # Basic OS health check for HyprRice on Arch Linux
-set -euo pipefail
+set -Eeuo pipefail
+
+handle_error() {
+    local exit_code=$?
+    local line_number=$1
+    local command=$2
+    echo "ERROR: Command failed with exit code $exit_code at line $line_number: $command" >&2
+    exit $exit_code
+}
+
+trap 'handle_error $LINENO "$BASH_COMMAND"' ERR
 
 RED='\e[31m'; GREEN='\e[32m'; YELLOW='\e[33m'; RESET='\e[0m'
 errors=0

--- a/update.sh
+++ b/update.sh
@@ -1,7 +1,17 @@
 #!/usr/bin/env bash
 # Simple updater for HyprRice dotfiles.
 # Pulls latest git changes and re-installs configuration.
-set -euo pipefail
+set -Eeuo pipefail
+
+handle_error() {
+    local exit_code=$?
+    local line_number=$1
+    local command=$2
+    echo "ERROR: Command failed with exit code $exit_code at line $line_number: $command" >&2
+    exit $exit_code
+}
+
+trap 'handle_error $LINENO "$BASH_COMMAND"' ERR
 
 TARGET_USER=${SUDO_USER:-${USER:-$(id -un)}}
 TARGET_HOME=$(eval echo "~$TARGET_USER")

--- a/validate.sh
+++ b/validate.sh
@@ -1,6 +1,16 @@
 #!/usr/bin/env bash
 # Validation script for HyprRice configuration
-set -uo pipefail
+set -Eeuo pipefail
+
+handle_error() {
+    local exit_code=$?
+    local line_number=$1
+    local command=$2
+    echo "ERROR: Command failed with exit code $exit_code at line $line_number: $command" >&2
+    exit $exit_code
+}
+
+trap 'handle_error $LINENO "$BASH_COMMAND"' ERR
 
 RED='\e[31m'
 GREEN='\e[32m'


### PR DESCRIPTION
## Summary
- add trap-based error handling to installer and updater scripts
- add consistent `set -Eeuo pipefail` and error handler to support scripts

## Testing
- `bash -n install.sh update.sh setup.sh install_tv.sh system_check.sh fix_login_theme.sh fix_sound.sh validate.sh`
- `./validate.sh` *(fails: Exec commands [ERROR], Waybar commands [ERROR])* 
- `./system_check.sh` *(fails: missing commands and inactive services)*


------
https://chatgpt.com/codex/tasks/task_e_6890c082e314833089893ae992f56535