### PR TITLE
fix for-loop termination in installer

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -24,7 +24,7 @@ AUR_PKGS=(greetd-tuigreet)
 missing=()
 for pkg in "${PACMAN_PKGS[@]}"; do
     pacman -Qi "$pkg" >/dev/null 2>&1 || missing+=("$pkg")
-fi
+done
 if ((${#missing[@]})); then
     echo -e "Installing packages: ${missing[*]}"
     sudo pacman -S --needed --noconfirm "${missing[@]}"


### PR DESCRIPTION
## Summary
- correct `install.sh` for-loop termination with `done`

## Testing
- `bash -n install.sh`
- `./validate.sh` *(fails: System has not been booted with systemd as init system)*

------
https://chatgpt.com/codex/tasks/task_e_6890dbb1ed6c8330ac9767112e288b4c