### PR TITLE
Fix audio script syntax and streamline login theme

### DIFF
--- a/fix_login_theme.sh
+++ b/fix_login_theme.sh
@@ -9,8 +9,7 @@ CFG_SRC="$SCRIPT_DIR/greetd/config.toml"
 CFG_DST="/etc/greetd/config.toml"
 
 if [[ $EUID -ne 0 ]]; then
-    echo -e "${RED}Run as root to modify greetd config.${RESET}"
-    exit 1
+    exec sudo "$0" "$@"
 fi
 
 install -Dm644 "$CFG_SRC" "$CFG_DST"

--- a/fix_sound.sh
+++ b/fix_sound.sh
@@ -16,7 +16,7 @@ REQ=(pipewire pipewire-pulse pipewire-alsa wireplumber alsa-utils pulsemixer)
 missing=()
 for p in "${REQ[@]}"; do
     pacman -Qi "$p" >/dev/null 2>&1 || missing+=("$p")
-fi
+done
 if ((${#missing[@]})); then
     sudo pacman -S --needed --noconfirm "${missing[@]}"
 fi


### PR DESCRIPTION
## Summary
- fix syntax error in audio migration script
- run login theme setup with sudo automatically

## Testing
- `for f in $(find . -name '*.sh'); do echo "Checking $f"; bash -n $f || echo "Error in $f"; done`

------
https://chatgpt.com/codex/tasks/task_e_6890df5159b483308193582b5f154a2e