### PR TITLE
Handle missing systemd in validate script

### DIFF
--- a/validate.sh
+++ b/validate.sh
@@ -19,13 +19,17 @@ check() {
 check "hyprctl" command -v hyprctl
 
 if command -v systemctl >/dev/null 2>&1; then
-    if systemctl --failed --no-legend | grep . >/dev/null 2>&1; then
-        echo -e "Failed systemd units present: ${RED}ERROR${RESET}"
-        errors=$((errors+1))
+    if systemctl is-system-running >/dev/null 2>&1; then
+        if systemctl --failed --no-legend | grep . >/dev/null 2>&1; then
+            echo -e "Failed systemd units present: ${RED}ERROR${RESET}"
+            errors=$((errors+1))
+        else
+            echo -e "systemctl --failed: ${GREEN}OK${RESET}"
+        fi
+        check "greetd active" systemctl is-active greetd.service
     else
-        echo -e "systemctl --failed: ${GREEN}OK${RESET}"
+        echo -e "systemd not running: ${YELLOW}skipping system checks${RESET}"
     fi
-    check "greetd active" systemctl is-active greetd.service
 else
     echo -e "systemctl: ${YELLOW}not found${RESET}"
 fi


### PR DESCRIPTION
## Summary
- avoid abrupt exits when systemd isn't running by skipping systemctl checks

## Testing
- `for f in $(find . -name "*.sh"); do echo "Checking $f"; bash -n "$f" && echo "OK"; done`
- `./validate.sh` *(fails: hyprctl: ERROR; systemd not running; pactl: not found)*


------
https://chatgpt.com/codex/tasks/task_e_6890e29435fc8330ba32bbeb543d9a5f