### PR TITLE
Add pacman check and basic syntax tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## Unreleased
+- add dependency check for `pacman` in `fix_sound.sh` to prevent execution on non-Arch systems
+- add `tests/test_syntax.sh` to verify shell scripts parse correctly
+- add `install_and_run.sh` helper to execute tests in one command

--- a/fix_sound.sh
+++ b/fix_sound.sh
@@ -6,6 +6,11 @@ GREEN="\e[32m"; RED="\e[31m"; YELLOW="\e[33m"; RESET="\e[0m"
 
 echo -e "${GREEN}Switching to PipeWire audio stack...${RESET}"
 
+if ! command -v pacman >/dev/null 2>&1; then
+    echo -e "${RED}pacman not found. Aborting.${RESET}"
+    exit 1
+fi
+
 PA_PKGS=$(pacman -Qq | grep -E '^pulseaudio' || true)
 if [[ -n $PA_PKGS ]]; then
     echo -e "Removing PulseAudio: $PA_PKGS"

--- a/install_and_run.sh
+++ b/install_and_run.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Ensure tests are executable
+chmod +x tests/test_syntax.sh
+
+# Run tests
+bash tests/test_syntax.sh

--- a/tests/test_syntax.sh
+++ b/tests/test_syntax.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+fail=0
+for script in *.sh; do
+    if bash -n "$script"; then
+        echo "$script: OK"
+    else
+        echo "$script: FAIL"
+        fail=$((fail+1))
+    fi
+done
+
+if ((fail)); then
+    echo "$fail script(s) failed syntax check" >&2
+    exit 1
+fi
+
+echo "All scripts passed syntax check"


### PR DESCRIPTION
## Summary
- ensure `fix_sound.sh` aborts when `pacman` is missing
- add minimal syntax test suite for shell scripts
- provide `install_and_run.sh` to execute tests

## Testing
- `bash tests/test_syntax.sh`


------
https://chatgpt.com/codex/tasks/task_e_689191ebc7fc833094ac2ec09fa3de03