### PR TITLE
Add TV launcher and unified setup runner

### DIFF
--- a/install_tv.sh
+++ b/install_tv.sh
@@ -29,10 +29,26 @@ PYTHON_BIN="$(command -v python3 || command -v python)"
 "$PYTHON_BIN" -m venv "$VENV_DIR"
 source "$VENV_DIR/bin/activate"
 python -m pip install --upgrade pip
-python -m pip install pyqt5 yt-dlp ffmpeg-python
+python -m pip install pyqt5 yt-dlp ffmpeg-python flask
 if [ -f "$TV_DIR/requirements.txt" ]; then
     python -m pip install -r "$TV_DIR/requirements.txt"
 fi
 deactivate
+
+chmod +x "$REPO_DIR/run_tv.sh"
+
+TARGET_USER=${SUDO_USER:-$USER}
+TARGET_HOME=$(eval echo "~$TARGET_USER")
+DESKTOP_FILE="$TARGET_HOME/.local/share/applications/tv.desktop"
+mkdir -p "$(dirname "$DESKTOP_FILE")"
+cat > "$DESKTOP_FILE" <<EOF
+[Desktop Entry]
+Type=Application
+Name=TV
+Exec=$REPO_DIR/run_tv.sh
+Terminal=false
+Categories=Video;
+EOF
+chown "$TARGET_USER":"$TARGET_USER" "$DESKTOP_FILE"
 
 echo -e "${GREEN}TV application environment ready in $VENV_DIR${RESET}"

--- a/run_all.sh
+++ b/run_all.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# run_all.sh: execute all setup scripts with logging
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOG_DIR="$HOME/HyprRice"
+LOG_FILE="$LOG_DIR/run_all.log"
+mkdir -p "$LOG_DIR"
+exec > >(tee -a "$LOG_FILE") 2>&1
+
+run_step() {
+    local desc="$1" script="$2"
+    echo -ne "==> $desc... "
+    set +e
+    "$SCRIPT_DIR/$script"
+    local status=$?
+    set -e
+    if [ $status -eq 0 ]; then
+        echo "OK"
+    else
+        echo "FAIL"
+        exit $status
+    fi
+}
+
+run_step "Install packages" install.sh
+run_step "Apply login theme" fix_login_theme.sh
+run_step "Configure audio" fix_sound.sh
+run_step "Install TV app" install_tv.sh
+run_step "Update configs" update.sh
+run_step "Run syntax tests" tests/test_syntax.sh
+run_step "Run validation" validate.sh
+run_step "Run system check" system_check.sh
+
+echo "Everything installed correctly"

--- a/run_tv.sh
+++ b/run_tv.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# run_tv.sh: launch TV application using bundled virtual environment
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VENV_DIR="$SCRIPT_DIR/.venv"
+TV_DIR="$SCRIPT_DIR/tv"
+
+APP_SCRIPT=""
+for candidate in app.py main.py tv.py; do
+    if [ -f "$TV_DIR/$candidate" ]; then
+        APP_SCRIPT="$TV_DIR/$candidate"
+        break
+    fi
+done
+
+if [ -z "$APP_SCRIPT" ]; then
+    echo "No entry script found in $TV_DIR" >&2
+    exit 1
+fi
+
+exec "$VENV_DIR/bin/python" "$APP_SCRIPT" "$@"


### PR DESCRIPTION
## Summary
- Ensure TV app installs dependencies in a venv and registers a Wofi launcher
- Provide `run_tv.sh` to launch the app with its virtual environment
- Add `run_all.sh` to sequentially run all setup scripts with logging

## Testing
- `bash tests/test_syntax.sh`


------
https://chatgpt.com/codex/tasks/task_e_6891b5328624833089e1efe85819d97a