### PR TITLE
Ensure shell scripts are syntax-checked recursively

### DIFF
--- a/tests/test_syntax.sh
+++ b/tests/test_syntax.sh
@@ -2,14 +2,16 @@
 set -euo pipefail
 
 fail=0
-for script in *.sh; do
+
+# Check syntax of all tracked shell scripts in the repository
+while IFS= read -r script; do
     if bash -n "$script"; then
         echo "$script: OK"
     else
         echo "$script: FAIL"
         fail=$((fail+1))
     fi
-done
+done < <(git ls-files '*.sh')
 
 if ((fail)); then
     echo "$fail script(s) failed syntax check" >&2


### PR DESCRIPTION
## Summary
- test: check shell scripts recursively

## Testing
- `bash tests/test_syntax.sh`
- `bash validate.sh` *(fails: hyprctl: ERROR; pactl: not found)*
- `bash system_check.sh` *(fails: pacman not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893ddfd56d883309f8205713ff4afc5