### PR TITLE
Add Python Arcade desktop integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ virtual environment and place a launcher in your desktop menu. After
 installation launch the app from your application menu or via the `TVPlayer`
 shortcut created on your Desktop.
 
+If `~/PythonArcade/arcade` is present, HyprRice automatically adds a Python Arcade launcher to Wofi.
+
 ## About
 
 HyprRice is a matrix-inspired configuration for the [Hyprland](https://github.com/hyprwm/Hyprland) Wayland compositor. It aims for a clean and minimal look with sharp edges and bright green accents.

--- a/install.sh
+++ b/install.sh
@@ -14,7 +14,7 @@ PACMAN_PKGS=(
     hyprland greetd pipewire pipewire-pulse pipewire-alsa wireplumber
     alsa-utils pulsemixer grim slurp swaybg swaylock swayidle
     networkmanager network-manager-applet bluez bluez-utils blueman
-    brightnessctl jq ffmpeg gstreamer gst-plugins-good gst-libav
+    brightnessctl jq ffmpeg gstreamer gst-plugins-good gst-libav desktop-file-utils
     xdg-desktop-portal xdg-desktop-portal-hyprland
     ttf-jetbrains-mono-nerd ttf-font-awesome polkit-gnome
     power-profiles-daemon
@@ -52,5 +52,8 @@ for dir in hypr waybar wofi wlogout; do
     chown -R "$TARGET_USER":"$TARGET_USER" "$CONFIG_DEST/$dir"
 
 done
+
+SCRIPT_ROOT="$(cd "$(dirname "$0")" && pwd)"
+sudo -u "$TARGET_USER" bash -c "source '$SCRIPT_ROOT/scripts/install_python_arcade_desktop.sh' && install_python_arcade_desktop"
 
 echo -e "${GREEN}Package installation and config deployment complete.${RESET}"

--- a/scripts/install_python_arcade_desktop.sh
+++ b/scripts/install_python_arcade_desktop.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+install_python_arcade_desktop() {
+    local arcade_dir="$HOME/PythonArcade/arcade"
+    if [[ ! -d "$arcade_dir" ]]; then
+        echo "PythonArcade not found; skipping desktop entry."
+        return 0
+    fi
+
+    mkdir -p "$HOME/.local/share/applications"
+    local desktop_path="$HOME/.local/share/applications/python-arcade.desktop"
+    local tmp_file
+    tmp_file="$(mktemp)"
+
+    cat >"$tmp_file" <<'DESKTOP'
+[Desktop Entry]
+Type=Application
+Name=Python Arcade
+Comment=Matrix-style mini-game hub (Pygame)
+Exec=/bin/bash -lc 'cd ~/PythonArcade/arcade && ./run.sh || (SDL_VIDEODRIVER=wayland python main.py || SDL_VIDEODRIVER=x11 python main.py)'
+Icon=applications-games
+Terminal=false
+Categories=Game;
+DESKTOP
+
+    mv "$tmp_file" "$desktop_path"
+
+    update-desktop-database "$HOME/.local/share/applications" || true
+    desktop-file-validate "$desktop_path" || true
+
+    echo "Python Arcade desktop entry installed."
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    install_python_arcade_desktop "$@"
+fi

--- a/update.sh
+++ b/update.sh
@@ -210,6 +210,9 @@ for dir in "${DIRS[@]}"; do
     progress $step $total
 done
 
+# Install Python Arcade desktop entry if available
+sudo -u "$TARGET_USER" bash -c "source '$SCRIPT_DIR/scripts/install_python_arcade_desktop.sh' && install_python_arcade_desktop"
+
 # Validate configuration
 if [[ -x "$SCRIPT_DIR/validate.sh" ]]; then
     sudo -u "$TARGET_USER" "$SCRIPT_DIR/validate.sh" || echo "Validation reported issues."


### PR DESCRIPTION
## Summary
- add helper script to generate Python Arcade desktop entry
- call helper from install.sh and update.sh and ensure `desktop-file-utils` dependency
- document automatic Python Arcade Wofi launcher

## Testing
- `bash tests/test_syntax.sh`
- `bash validate.sh`

------
https://chatgpt.com/codex/tasks/task_e_6897062830a08330aeafde06b3d4778c