### PR TITLE
Add help command and shortcuts window

### DIFF
--- a/.config/hypr/hyprland.conf
+++ b/.config/hypr/hyprland.conf
@@ -42,6 +42,7 @@ bind = $mod, C, exec, ~/.config/hypr/scripts/center-fullscreen.sh
 bind = $mod, W, forcekillactive
 bind = $mod, L, exec, swaylock
 bind = $mod, M, exec, wlogout
+bind = $mod, H, exec, ~/.config/hypr/scripts/show_shortcuts.sh
 bind = $mod, V, togglefloating
 bind = $mod, J, togglesplit
 bind = $mod, TAB, workspace, e+1

--- a/scripts/hyprrice-help.sh
+++ b/scripts/hyprrice-help.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+echo "HyprRice — available commands"
+echo
+printf " %-22s %s\n" "install.sh"       "Install packages and base config"
+printf " %-22s %s\n" "setup.sh"         "Umbrella setup (fixes, optional TV app, etc.)"
+printf " %-22s %s\n" "update.sh"        "Sync configs, refresh menus, reload Hyprland/Waybar"
+printf " %-22s %s\n" "system_check.sh"  "Diagnostics: graphics/audio/services"
+printf " %-22s %s\n" "validate.sh"      "Lint/syntax/style sanity checks"
+echo
+echo "Versions:"
+for c in hyprland hyprctl waybar wofi wlogout swaybg swayidle swaylock alacritty thunar firefox nm-connection-editor blueman pulsemixer ffmpeg yt-dlp python; do
+  if command -v "$c" >/dev/null 2>&1; then printf "  %-22s %s\n" "$c" "$($c --version 2>/dev/null | head -n1)"; else printf "  %-22s %s\n" "$c" "MISSING"; fi
+done

--- a/scripts/hyprrice-shortcuts.desktop
+++ b/scripts/hyprrice-shortcuts.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Name=HyprRice Shortcuts
+Comment=View all Super shortcuts
+Exec=/bin/sh -lc "$HOME/.config/hypr/scripts/show_shortcuts.sh"
+Terminal=false
+Type=Application
+Icon=preferences-desktop-keyboard
+Categories=System;Utility;

--- a/scripts/show_shortcuts.sh
+++ b/scripts/show_shortcuts.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+CHEAT="$HOME/.config/hypr/shortcuts.txt"
+[ -f "$CHEAT" ] || cat > "$CHEAT" <<'TXT'
+HyprRice — Super shortcuts (default)
+  Super+Enter      Terminal (Alacritty)
+  Super+Space      Wofi launcher
+  Super+E / B      Thunar / Firefox
+  Super+L          Lock (swaylock)
+  Super+M          Power menu (wlogout)
+  Super+Q / W      Close / Force close
+  Super+F          Fullscreen
+  Super+V / J      Toggle floating / Toggle split
+  Super+Arrows     Focus window
+  Super+Shift+Arrows Move window
+  Super+Ctrl+Arrows  Send window to workspace
+  Super+1..9 / Shift+1..9  Switch / Move to workspace
+  Super+Tab / Shift+Tab    Next / Prev workspace
+  Alt+Tab / Shift+Tab      Cycle windows
+  Print / Super+S          Screenshot full / region
+TXT
+# open in a terminal with less (fallback order)
+for term in alacritty foot kitty xterm; do
+  if command -v "$term" >/dev/null 2>&1; then exec "$term" -e bash -lc "less -R \"$CHEAT\""; fi
+done
+# if no terminal found, try wofi preview as a fallback
+wofi --dmenu < "$CHEAT"

--- a/update.sh
+++ b/update.sh
@@ -224,6 +224,17 @@ for dir in "${DIRS[@]}"; do
     progress $step $total
 done
 
+# Install helper and shortcut scripts
+sudo install -m 755 "$SCRIPT_DIR/scripts/hyprrice-help.sh" /usr/local/bin/hyprrice-help.sh
+
+mkdir -p "$TARGET_HOME/.config/hypr/scripts"
+sudo install -m 755 "$SCRIPT_DIR/scripts/show_shortcuts.sh" "$TARGET_HOME/.config/hypr/scripts/show_shortcuts.sh"
+chown "$TARGET_USER":"$TARGET_USER" "$TARGET_HOME/.config/hypr/scripts/show_shortcuts.sh" || true
+
+sudo install -m 644 "$SCRIPT_DIR/scripts/hyprrice-shortcuts.desktop" "$APP_DIR/hyprrice-shortcuts.desktop"
+chown "$TARGET_USER":"$TARGET_USER" "$APP_DIR/hyprrice-shortcuts.desktop" || true
+sudo -u "$TARGET_USER" update-desktop-database "$APP_DIR" || true
+
 # Install Python Arcade desktop entry if available
 sudo -u "$TARGET_USER" bash -c "source '$SCRIPT_DIR/scripts/install_python_arcade_desktop.sh' && install_python_arcade_desktop"
 
@@ -246,6 +257,10 @@ if command -v hyprctl >/dev/null 2>&1; then
     fi
     # reload waybar to pick up new configuration
     sudo -u "$TARGET_USER" pkill -SIGUSR2 waybar 2>/dev/null || true
+fi
+
+if [[ -x "$SCRIPT_DIR/system_check.sh" ]]; then
+    "$SCRIPT_DIR/system_check.sh" || true
 fi
 
 echo -e "\nHyprRice update complete."


### PR DESCRIPTION
## Summary
- add `hyprrice-help` utility script to show commands and versions
- provide `show_shortcuts.sh` plus desktop entry and keybinding for easy shortcut viewing
- update updater to install helper scripts, refresh desktop database, and run `system_check.sh`

## Testing
- `bash scripts/hyprrice-help.sh | head -n 20`
- `bash system_check.sh | head -n 20`
- `bash validate.sh >/tmp/validate.log && tail -n 20 /tmp/validate.log`


------
https://chatgpt.com/codex/tasks/task_e_6899ba85c4788330bce6092fa420b2f6