### PR TITLE
Improve power menu and window management

### DIFF
--- a/.config/hypr/hyprland.conf
+++ b/.config/hypr/hyprland.conf
@@ -26,9 +26,9 @@ misc {
 
 animations {
     enabled = 1
-    animation = windows, 1, 3, default
-    animation = workspaces, 1, 5, default
-    animation = fade, 1, 3, default
+    animation = windows, 1, 8, slide
+    animation = workspaces, 1, 8, slide
+    animation = fade, 1, 5, default
 }
 
 # Keybindings
@@ -44,6 +44,7 @@ bind = $mod, L, exec, swaylock
 bind = $mod, M, exec, wlogout
 bind = $mod, H, exec, ~/.config/hypr/scripts/show_shortcuts.sh
 bind = $mod, V, togglefloating
+bind = $mod, N, exec, ~/.config/hypr/scripts/cycle_float_sizes.sh
 bind = $mod, J, togglesplit
 bind = $mod, TAB, workspace, e+1
 bind = $mod SHIFT, TAB, workspace, e-1
@@ -79,3 +80,6 @@ bind = $mod SHIFT, 6, movetoworkspace, 6
 bind = $mod SHIFT, 7, movetoworkspace, 7
 bind = $mod SHIFT, 8, movetoworkspace, 8
 bind = $mod SHIFT, 9, movetoworkspace, 9
+bindc = ALT, mouse:272, togglefloating
+bindm = ALT, mouse:272, movewindow
+bindm = ALT, mouse:273, resizewindow

--- a/.config/hypr/scripts/cycle_float_sizes.sh
+++ b/.config/hypr/scripts/cycle_float_sizes.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Cycle floating window through preset sizes
+set -euo pipefail
+active=$(hyprctl -j activewindow 2>/dev/null)
+[ -z "$active" ] && exit 0
+mon=$(echo "$active" | jq -r '.monitor')
+minfo=$(hyprctl -j monitors | jq -r ".[] | select(.name==\"$mon\")")
+width=$(echo "$minfo" | jq '.width')
+height=$(echo "$minfo" | jq '.height')
+smallw=$((width / 2))
+smallh=$((height / 2))
+medw=$((width * 3 / 4))
+medh=$((height * 3 / 4))
+fullw=$width
+fullh=$height
+floating=$(echo "$active" | jq -r '.floating')
+if [ "$floating" = "false" ]; then
+  hyprctl dispatch togglefloating
+  hyprctl dispatch resizeactive exact "$smallw" "$smallh"
+  hyprctl dispatch centerwindow
+  exit 0
+fi
+curw=$(echo "$active" | jq '.size[0]')
+if [ "$curw" -le $((smallw + 5)) ]; then
+  hyprctl dispatch resizeactive exact "$medw" "$medh"
+elif [ "$curw" -le $((medw + 5)) ]; then
+  hyprctl dispatch resizeactive exact "$fullw" "$fullh"
+else
+  hyprctl dispatch resizeactive exact "$smallw" "$smallh"
+fi
+hyprctl dispatch centerwindow

--- a/.config/waybar/config
+++ b/.config/waybar/config
@@ -22,7 +22,7 @@
     "tray"
   ],
   "clock": {
-    "format": "{:%A %d %B %I:%M %p}",
+    "format": "{:%A %d %B} <b><big>{:%I:%M %p}</big></b>",
     "tooltip": true,
     "tooltip-format": "<tt><big>{calendar}</big></tt>",
     "on-click": "alacritty -e cal",
@@ -83,7 +83,7 @@
     "on-click": "xfce4-power-manager-settings"
   },
   "hyprland/workspaces": {
-    "format": "{id}",
+    "format": "{id}{icon}",
     "active-only": false,
     "persistent-workspaces": {
       "*": 9
@@ -92,6 +92,11 @@
     "on-scroll-down": "hyprctl dispatch workspace e-1",
     "on-click": "activate",
     "tooltip": true,
-    "tooltip-format": "Workspace {id}: {windows} windows"
+    "tooltip-format": "Workspace {id}: {windows} windows",
+    "format-icons": {
+      "empty": "▢",
+      "persistent": "▣",
+      "active": "▣"
+    }
   }
 }

--- a/.config/wlogout/layout
+++ b/.config/wlogout/layout
@@ -1,5 +1,7 @@
-logout,hyprctl dispatch exit,,Logout
-reboot,systemctl reboot,,Reboot
-shutdown,systemctl poweroff,,Shutdown
-lock,swaylock,,Lock
-suspend,systemctl suspend,,Suspend
+[
+  { "label": "logout",   "action": "hyprctl dispatch exit", "text": " Logout",   "keybind": "l" },
+  { "label": "reboot",   "action": "systemctl reboot",      "text": " Reboot",   "keybind": "r" },
+  { "label": "shutdown", "action": "systemctl poweroff",    "text": " Shutdown", "keybind": "s" },
+  { "label": "lock",     "action": "swaylock",              "text": " Lock",     "keybind": "k" },
+  { "label": "suspend",  "action": "systemctl suspend",     "text": " Suspend",  "keybind": "u" }
+]


### PR DESCRIPTION
## Summary
- Fix wlogout by replacing comma-separated layout with JSON layout and keybinds
- Highlight occupied Hyprland workspaces and enlarge clock time on Waybar
- Add floating window size cycling script, Alt-drag bindings, and smoother animations in Hyprland

## Testing
- `HOME=$(pwd) ./scripts/check_hyprrice.sh` *(fails: hyprctl missing)*
- `apt-get update` *(fails: repository not signed)*
- `apt-get install -y hyprland` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_689afbd68d808330a2860349c66fd404