### PR TITLE
Avoid overwriting local configs during update

### DIFF
--- a/.config/hypr/hyprland.conf
+++ b/.config/hypr/hyprland.conf
@@ -26,8 +26,8 @@ misc {
 
 animations {
     enabled = 1
-    animation = windows, 1, 8, slide
-    animation = workspaces, 1, 8, slide
+    animation = windows, 1, 8, default, slide
+    animation = workspaces, 1, 8, default, slide
     animation = fade, 1, 5, default
 }
 

--- a/.config/waybar/config
+++ b/.config/waybar/config
@@ -21,9 +21,9 @@
     "battery",
     "tray"
   ],
-  "clock": {
-    "format": "{:%A %d %B} <b><big>{:%I:%M %p}</big></b>",
-    "tooltip": true,
+    "clock": {
+      "format": " {:%A %d %B} <b><big>{:%I:%M %p}</big></b>",
+      "tooltip": true,
     "tooltip-format": "<tt><big>{calendar}</big></tt>",
     "on-click": "alacritty -e cal",
     "calendar": {


### PR DESCRIPTION
## Summary
- prevent `update.sh` from resetting local config and use git pull for repo updates
- fix missing bezier errors in Hyprland animations
- add clock icon to waybar and ensure rsync is installed for updates

## Testing
- `./tests/test_syntax.sh`
- `./validate.sh` *(fails: hyprctl: ERROR; systemd not running; pactl: not found)*


------
https://chatgpt.com/codex/tasks/task_e_689ef0a71f448330a87b1f45cce3a342