### PR TITLE
Fix wlogout layout JSON escapes

### DIFF
--- a/.config/wlogout/layout
+++ b/.config/wlogout/layout
@@ -1,7 +1,7 @@
 [
-  { "label": "logout",   "action": "hyprctl dispatch exit", "text": " Logout",   "keybind": "l" },
-  { "label": "reboot",   "action": "systemctl reboot",      "text": " Reboot",   "keybind": "r" },
-  { "label": "shutdown", "action": "systemctl poweroff",    "text": " Shutdown", "keybind": "s" },
-  { "label": "lock",     "action": "swaylock",              "text": " Lock",     "keybind": "k" },
-  { "label": "suspend",  "action": "systemctl suspend",     "text": " Suspend",  "keybind": "u" }
+  { "label": "logout",   "action": "hyprctl dispatch exit", "text": "\uf011 Logout",   "keybind": "l" },
+  { "label": "reboot",   "action": "systemctl reboot",      "text": "\uf01e Reboot",   "keybind": "r" },
+  { "label": "shutdown", "action": "systemctl poweroff",    "text": "\uf085 Shutdown", "keybind": "s" },
+  { "label": "lock",     "action": "swaylock",              "text": "\uf023 Lock",     "keybind": "k" },
+  { "label": "suspend",  "action": "systemctl suspend",     "text": "\uf04c Suspend",  "keybind": "u" }
 ]


### PR DESCRIPTION
## Summary
- replace icon glyphs in wlogout layout with ASCII unicode escape sequences to avoid JSON parsing issues when launching from the power button

## Testing
- `./tests/test_syntax.sh`
- `scripts/check_hyprrice.sh` *(fails: hyprctl missing)*

------
https://chatgpt.com/codex/tasks/task_e_689ef69ffb508330a0205484835a00b2